### PR TITLE
[DEV APPROVED] 8978 - Sidepanel UI Component

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,2 +1,3 @@
 @import 'icons';
 @import 'list';
+@import 'buttons';

--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -1,0 +1,20 @@
+.btn {
+  @extend %border-radius;
+  border: 0;
+  cursor: pointer;
+  padding: $baseline-unit*2;
+  font-size: 1rem;
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  text-decoration: none;
+
+  @include respond-to($mq-m) {
+    width: auto;
+  }
+}
+
+.btn--primary {
+  background-color: $primary-blue-dark;
+  color: $color-white;
+}

--- a/app/assets/stylesheets/components/ui/_all.scss
+++ b/app/assets/stylesheets/components/ui/_all.scss
@@ -5,3 +5,4 @@
 @import 'download_box';
 @import 'feedback_box';
 @import 'large_cta';
+@import 'sidepanel';

--- a/app/assets/stylesheets/components/ui/_sidepanel.scss
+++ b/app/assets/stylesheets/components/ui/_sidepanel.scss
@@ -1,0 +1,69 @@
+.sidepanel {
+  background-color: $color-blue-lighter;
+  padding: $baseline-unit*2;
+  margin-bottom: $baseline-unit;
+}
+
+.sidepanel__title {
+  @include body(20, 24);
+  color: $primary-blue-dark;
+  font-weight: 500;
+  padding: 0 0 $baseline-unit*2;
+  margin: 0;
+}
+
+.sidepanel__subtitle {
+  @include body(18, 24);
+  color: $primary-blue-dark;
+  font-weight: 500;
+  padding: 0;
+  margin: $baseline-unit*2 0;
+}
+
+.sidepanel__list {
+  list-style: none;
+  margin: 0;
+  padding-left: 0;
+}
+
+.sidepanel__list-item {
+  &:before {
+    background-color: $primary-blue-dark;
+    border-radius: 50%;
+    content: "";
+    display: inline-block;
+    margin-right: $baseline-unit;
+    margin-bottom: 2px;
+    height: 5px;
+    width: 5px;
+  }
+}
+
+.sidepanel__list-item-link {
+  text-decoration: underline;
+}
+
+// Form Elements
+
+.sidepanel__text-field {
+  @extend %border-radius;
+  width: calc(100% - #{$baseline-unit*4});
+  border: 0;
+  margin-bottom: $baseline-unit;
+  padding: $baseline-unit*2;
+  font-size: 1rem;
+}
+
+.sidepanel__checkbox,
+.sidepanel__radio {
+  display: block;
+  padding: $baseline-unit/2 0;
+}
+
+// Forces full width on larger screen sizes
+.sidepanel__btn {
+  @include respond-to($mq-m) {
+    width: 100%;
+    margin-bottom: $baseline-unit;
+  }
+}

--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -16,7 +16,8 @@ class StyleguideController < ApplicationController
       'Latest news' => 'latestnews',
       'Download box' => 'downloads',
       'Feedback' => 'feedback',
-      'Large call to action' => 'largecta'
+      'Large call to action' => 'largecta',
+      'Side panel' => 'sidepanel'
     }
   end
 

--- a/app/views/styleguide/sidepanel.html.erb
+++ b/app/views/styleguide/sidepanel.html.erb
@@ -1,0 +1,157 @@
+<h1>UI Components</h1>
+<h2>Side Panel</h2>
+<p>The side panel UI component can be used in a number of places with varying content.</p>
+<h3 class="styleguide__subheading">Sidepanel container</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    This is a sidepanel
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <div class="sidepanel">
+    This is a sidepanel
+  </div>
+</xmp>
+<h3 class="styleguide__subheading">Title &amp; Sub-title</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <h4 class="sidepanel__title">Title</h4>
+    <h5 class="sidepanel__subtitle">Sub-title</h5>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <h4 class="sidepanel__title">Title</h4>
+  <h5 class="sidepanel__subtitle">Sub-title</h5>
+</xmp>
+<h3 class="styleguide__subheading">Link list</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <ul class="sidepanel__list">
+      <li class="sidepanel__list-item">
+        <a href="http://www.fincap.org.uk" class="sidepanel__list-item-link">
+          List item
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <ul class="sidepanel__list">
+    <li class="sidepanel__list-item">
+      <a href="#" class="sidepanel__list-item-link">
+        List item
+      </a>
+    </li>
+  </ul>
+</xmp>
+<h3 class="styleguide__subheading">Paragraph</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <p>Uses default paragraph styles and spacing</p>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <p>Uses default paragraph styles and spacing</p>
+</xmp>
+
+<h2>Form Elements</h2>
+<h3 class="styleguide__subheading">Text input</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <input type="text" class="sidepanel__text-field" />
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <input type="text" class="sidepanel__text-field" />
+</xmp>
+<h3 class="styleguide__subheading">Input button</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <button class="btn btn--primary sidepanel__btn">
+      Input button
+    </button>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <button class="btn btn--primary sidepanel__btn">
+    Input button
+  </button>
+</xmp>
+<h3 class="styleguide__subheading">Checkboxes</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <label class="sidepanel__checkbox">
+      <input type="checkbox"> Checkbox Label
+    </label>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <label class="sidepanel__checkbox">
+    <input type="checkbox"> Checkbox Label
+  </label>
+</xmp>
+<h3 class="styleguide__subheading">Radio buttons</h3>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <div class="sidepanel__radio">
+      <input type="radio" id="sample_radio_button" name="name" value="label_value">
+      <label for="sample_radio_button">label value</label>
+    </div>
+  </div>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <div class="sidepanel__radio">
+    <input type="radio" id="sample_radio_button" name="name" value="label_value">
+    <label for="sample_radio_button">label value</label>
+  </div>
+</xmp>
+<h2>Example usage</h2>
+<div class="styleguide__example">
+  <div class="sidepanel">
+    <h4 class="sidepanel__title">Title</h4>
+    <h5 class="sidepanel__subtitle">Form</h5>
+    <input type="text" class="sidepanel__text-field" />
+    <button class="btn btn--primary sidepanel__btn">
+      Input button
+    </button>
+    <h5 class="sidepanel__subtitle">Generic content</h5>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce lacinia egestas sapien. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec sed purus quis turpis rhoncus congue.
+    </p>
+    <h5 class="sidepanel__subtitle">Link list</h5>
+    <ul class="sidepanel__list">
+      <% 5.times do %>
+        <li class="sidepanel__list-item">
+          <a href="https://www.fincap.org.uk" class="sidepanel__list-item-link">
+            List item
+          </a>
+        </li>
+      <% end %>
+    </ul>
+    <h5 class="sidepanel__subtitle">Checkboxes</h5>
+    <% 5.times do %>
+      <label class="sidepanel__checkbox">
+        <input type="checkbox"> Checkbox
+      </label>
+    <% end %>
+    <h5 class="sidepanel__subtitle">Radio buttons</h5>
+    <% 5.times do %>
+      <div class="sidepanel__radio">
+        <input type="radio" id="sample_radio_button" name="name" value="label_value">
+        <label for="sample_radio_button">Radio option</label>
+      </div>
+    <% end %>
+  </div>
+  <div class="sidepanel">
+    <h4 class="sidepanel__title">Additional sidepanel</h4>
+    <p>To represent spacing when multiple panels are present.</p>
+  </div>
+</div>


### PR DESCRIPTION
# 8978 - Sidepanel UI Component

[TP Ticket 8978](https://moneyadviceservice.tpondemand.com/entity/8978-styleguide-ui-component-evidence-hub-key)

Adds sidepanel UI component to the fincap styleguide.

This component is to be used in multiple places, including search and also insight and evaluation pages.  Therefore it shows how to construct the sidepanel for any instance.

This PR also includes some base button styles, a full PR for buttons will be included in an additional PR shortly.

**This PR includes:**

- Addition of the sidepanel page
- Adds new page to styleguide navigation
- Displays how each content element will be displayed
- Shows an example of a complete sidepanel

| Screenshot |
|-------------|
|![image](https://user-images.githubusercontent.com/13165846/36417414-cf6a5084-1623-11e8-9d9b-7e8b8474bad7.png)|
