### PR TITLE
[DEV APPROVED] Refactor external links css

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -40,7 +40,8 @@ a {
     color: $primary-orange;
   }
 
-  &:not([href*="#{$site}"]):after {
+  &[href^="http:"]:not([href*="#{$site}"]):after,
+  &[href^="https:"]:not([href*="#{$site}"]):after {
     @extend %icon;
     @extend .icon--external-link;
     content: '';


### PR DESCRIPTION
# Refactor external links css

This PR makes a minor improvement to the CSS selector for detecting an external link.

The current solution is not specific enough and does not provide enough flexibility:

```
:not([href*="#{$site}"])
```

The problem with the above line of CSS is that any link which doesn't include fincap.org.uk is treated as an external link, this **includes** internal links like ``/contact-us``

The new solution is more specific:

```
[href^="http:"]:not([href*="#{$site}"]),
[href^="https:"]:not([href*="#{$site}"])
```

The rule now evaluates any link URL, and if it contains http:// or https:// **AND** isn't pointing to fincap.org.uk it will be treated as an external link:

I have tested this with below URL's all return the correct result:

- /contact-us
- /
- https://ww.fincap.org.uk
- http://fincap.org.uk
- https://www.google.com
- http://moneyadviceservice.org.uk