### PR TITLE
Search results 'i' icon improvement

### DIFF
--- a/app/assets/stylesheets/components/ui/_search_results.scss
+++ b/app/assets/stylesheets/components/ui/_search_results.scss
@@ -48,12 +48,15 @@ a.search-results__evidence-type-link {
   }
 
   &:after {
-    @include body (11, 24);
+    @include body (11, 22);
     content: 'i';
     border-radius: 50%;
     background-image: none;
     color: $color-white;
+    display: inline-block;
     background-color: $primary-blue-dark;
     text-align: center;
+    height: $baseline-unit*3;
+    width: $baseline-unit*3;
   }
 }


### PR DESCRIPTION
# Search results 'i' icon improvement

Improves the display of the i icon on the search results evidence type.  The 'i' now better placed and more prominent.

![image](https://user-images.githubusercontent.com/13165846/36585215-dff6ecb6-1874-11e8-9cac-24edfceaed56.png)
