### PR TITLE
Removed buggy config on cucumber

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,4 @@
 <%
-rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
-rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags not @wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict"
 %>
 default: <%= std_opts %> features
-wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags not @wip


### PR DESCRIPTION
**No ticket** - But I am dependent of this fix for [8794](https://moneyadviceservice.tpondemand.com/entity/8794-evhub-insight-summary-page-website-view) card.

## Context

As far I understood, the cucumber rerun config does not work with not @wip. 

So since we are not using wip tags neither the rerun, removing the buggy config, makes the cucumber pass.