### PR TITLE
Validate before dynamic render the page

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--require rails_helper

--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -3,22 +3,43 @@ class StyleguideController < ApplicationController
   layout 'styleguide'
   include StyleguideHelper
 
+  before_action :validate_templates, only: :show
+
   def show
-    if params[:page] == 'colours'
+    if page_params == 'colours'
       @primary_colours    = PRIMARY_COLOURS
       @supporting_colours = SUPPORTING_COLOURS
       @mono_colours       = MONO_COLOURS
       @greys              = GREYS
     end
 
-    if params[:page] == 'buttons'
+    if page_params == 'buttons'
       @primary_colours    = PRIMARY_COLOURS
     end
 
-    render params[:page]
+    render page_params
   end
 
   private
+
+  STYLEGUIDE_VIEWS = Rails.root.join(
+    'app',
+    'views',
+    'styleguide',
+    '*.html.erb'
+  )
+
+  STYLEGUIDE_TEMPLATES = Dir[STYLEGUIDE_VIEWS].map do |template|
+    File.basename(template, '.html.erb')
+  end
+
+  def validate_templates
+    render body: nil, status: 404 unless page_params.in?(STYLEGUIDE_TEMPLATES)
+  end
+
+  def page_params
+    params.require(:page)
+  end
 
   def components
     @components = COMPONENTS

--- a/spec/controllers/styleguide_controller_spec.rb
+++ b/spec/controllers/styleguide_controller_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe StyleguideController do
+  describe 'GET /styleguide/:page' do
+    context 'when :page params is valid' do
+      before do
+        get :show, params: { page: 'colours' }
+      end
+
+      it 'responds successfully' do
+        expect(response).to be_ok
+      end
+    end
+
+    context 'when :page params is invalid' do
+      before do
+        get :show, params: { page: '/etc/passwd' }
+      end
+
+      it 'returns "Not Found"' do
+        expect(response.status).to be(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**No cards** but it is a dependency of the card [8794](https://moneyadviceservice.tpondemand.com/entity/8794-evhub-insight-summary-page-website-view) that I am working at the moment.

## Context

Be careful when you render dynamic templates like: `render params[:page]` because this dynamic render probably can add *security vulnerabilities*.

Such a simple code snippet **could** provided the ability for an attacker to read our source code and application configuration values.

Or depending the ability of the attacker, it could use this vulnerability to traverse directory on the server.

So validating the template before it renders it is the secure way to dynamic render the templates.

**Other observation is that on the code you can see that I added the render body: nil, status: 404. That's because we don't have at the moment a 404 page.**