### PR TITLE
9016 - Setup VCR for recording requests from Fincap CMS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'site_prism'
   gem 'sqlite3'
   gem 'tzinfo-data'
+  gem 'vcr'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
     uglifier (4.1.5)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    vcr (4.0.0)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -292,6 +293,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  vcr
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,10 @@ if Rails.env.production?
   abort('The Rails environment is running in production mode!')
 end
 
+Dir[
+  Rails.root.join('spec', 'support', '**.rb')
+].each { |f| require f }
+
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,16 @@
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :faraday
+
+  c.around_http_request do |request|
+    uri = URI(request.uri)
+
+    if ENV['FINCAP_CMS_URL'].match?(/#{uri.host}/)
+      VCR.use_cassette(
+        "/fincap_cms/#{request.method}#{uri.path}#{uri.query}",
+        allow_playback_repeats: true,
+        &request
+      )
+    end
+  end
+end


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9016-add-the-documentall-call-to-fincap) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

This is a dependency for [8773 TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights) and [8794 card](https://moneyadviceservice.tpondemand.com/entity/8794-evhub-insight-summary-page-website-view)

Setup VCR so VCR can record future cassettes when requesting to Fincap CMS.