### PR TITLE
[DEV APPROVED] 9017 - Add base presenter layer to the application

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     ast (2.4.0)
     backports (3.11.1)
     bindex (0.5.0)
+    bowndler (1.0.2)
+      thor
     brakeman (4.2.0)
     builder (3.2.3)
     capybara (2.17.0)
@@ -269,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bowndler (~> 1.0)
   brakeman
   capybara
   cucumber-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,16 @@
 module ApplicationHelper
+  def present(object)
+    klass = "#{object.class}Presenter".constantize
+    presenter = klass.new(object, self)
+
+    if block_given?
+      yield(presenter)
+    else
+      presenter
+    end
+  end
+
+  def present_collection(collection)
+    collection.map { |element| present(element) }
+  end
 end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,0 +1,18 @@
+class BasePresenter < SimpleDelegator
+  def self.map(collection, view)
+    collection.map { |element| new(element, view) }
+  end
+
+  attr_reader :object, :view
+
+  def initialize(object, view)
+    @object = object
+    @view = view
+
+    super(@object)
+  end
+
+  def h
+    @view
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe ApplicationHelper do
+  before do
+    class AnExample
+    end
+
+    class AnExamplePresenter < BasePresenter
+    end
+  end
+
+  let(:model) { AnExample.new }
+
+  describe '#present' do
+    context 'when not passing a block' do
+      it 'returns the respective presenter for the object' do
+        expect(helper.present(model)).to be_instance_of(AnExamplePresenter)
+      end
+    end
+
+    context 'when passing a block' do
+      it 'yields the respective presenter for the object' do
+        helper.present(model) do |presenter|
+          expect(presenter).to be_instance_of(AnExamplePresenter)
+        end
+      end
+    end
+  end
+
+  describe '#present_collection' do
+    subject(:present_collection) do
+      helper.present_collection([model])
+    end
+
+    it 'returns same size as the collection passed in args' do
+      expect(present_collection.size).to be(1)
+    end
+
+    it 'returns respective presenter for elements within the collection' do
+      expect(present_collection.first).to be_instance_of(AnExamplePresenter)
+    end
+  end
+end


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9017-format-for-displaying) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

This is a dependency for [8773 TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights) and [8794 card]

## Context

I was working on adding the search results on evidence hub summaries which I came to a point that I need refactor the [view](https://github.com/moneyadviceservice/fin_cap/blob/9017-evidence-hub-summaries/app/views/evidence_hub/index.html.erb#L15) **then I decided to open separated a PR which will only add the presenter base line.**

## Next PRs

- [ ] Add yardoc to fincap app
- [ ] Add presenters for Evidence Summary on https://github.com/moneyadviceservice/fin_cap/blob/9017-evidence-hub-summaries/app/views/evidence_hub/index.html.erb#L15 
- [ ] Open a PR on mas-cms-client which accepts to pass the document_type as params for the all call.
- [ ] Pass the "insight" as "document_type" on the Document.all call to CMS on fincap repo.