### PR TITLE
[DEV APPROVED] Add VCR to feature testing.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@
 # files.
 
 require 'cucumber/rails'
+require Rails.root.join('spec', 'support', 'vcr')
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9017-format-for-displaying) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

This is a dependency for [8773 TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights) and [8794 card]

I decided to use the same config that is using on RSpec
to avoid duplication config across RSpec and Cucumber.

With this configuration, any request to CMS from the feature tests will record and use the cassettes.