### PR TITLE
[DEV APPROVED] Add evidence summary model

### DIFF
--- a/app/models/evidence_summary.rb
+++ b/app/models/evidence_summary.rb
@@ -1,0 +1,61 @@
+class EvidenceSummary
+  def self.map(documents)
+    documents.map { |document| new(document) }
+  end
+
+  attr_reader :document
+  delegate :blocks,
+           :layout_identifier,
+           :label,
+           :full_path,
+           to: :document
+  alias title label
+
+  def initialize(document)
+    @document = document
+  end
+
+  def topics
+    find_blocks(:topics)
+  end
+
+  def evidence_type
+    layout_identifier.to_s.capitalize
+  end
+
+  def overview
+    find_block(:overview)
+  end
+
+  def countries
+    find_block(:countries)
+  end
+
+  def year_of_publication
+    find_block(:year_of_publication)
+  end
+
+  private
+
+  def find_blocks(block_identifier)
+    find_block(block_identifier, find_method: :select)
+  end
+
+  def find_block(block_identifier, find_method: :find)
+    fields = blocks.method(find_method).call do |block|
+      block['identifier'] == block_identifier.to_s
+    end
+
+    retrieve_content(fields)
+  end
+
+  def retrieve_content(fields)
+    return fields.to_s if fields.nil?
+
+    if fields.is_a?(Array)
+      fields.map { |field| field['content'] }
+    else
+      fields['content']
+    end
+  end
+end

--- a/spec/models/evidence_summary_spec.rb
+++ b/spec/models/evidence_summary_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe EvidenceSummary do
+  subject(:evidence_summary) { described_class.new(document) }
+  let(:document) do
+    Mas::Cms::Document.new(1, { blocks: blocks }.merge(attributes))
+  end
+  let(:attributes) { {} }
+  let(:blocks) { [] }
+
+  describe '#title' do
+    let(:attributes) { { 'label' => 'Financial well being' } }
+
+    it 'returns label from document' do
+      expect(evidence_summary.title).to eq('Financial well being')
+    end
+  end
+
+  describe '#evidence_type' do
+    context 'when layout identifier is present' do
+      let(:attributes) { { 'layout_identifier' => 'insight' } }
+
+      it 'returns layout identifier' do
+        expect(evidence_summary.evidence_type).to eq('Insight')
+      end
+    end
+
+    context 'when layout identifier is not present' do
+      it 'returns layout identifier' do
+        expect(evidence_summary.evidence_type).to eq('')
+      end
+    end
+  end
+
+  describe '#overview' do
+    context 'when overview is present' do
+      let(:blocks) do
+        [
+          { 'identifier' => 'overview', 'content' => 'overview content' }
+        ]
+      end
+
+      it 'returns overview content' do
+        expect(evidence_summary.overview).to eq('overview content')
+      end
+    end
+
+    context 'when overview is not present' do
+      it 'returns overview content' do
+        expect(evidence_summary.overview).to eq('')
+      end
+    end
+  end
+
+  describe '#year_of_publication' do
+    context 'when year of publication is present' do
+      let(:blocks) do
+        [
+          { 'identifier' => 'year_of_publication', 'content' => '2017' }
+        ]
+      end
+
+      it 'returns year of publication' do
+        expect(evidence_summary.year_of_publication).to eq('2017')
+      end
+    end
+
+    context 'when year of publication is not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.year_of_publication).to eq('')
+      end
+    end
+  end
+
+  describe '#countries' do
+    context 'when countries are present' do
+      let(:blocks) do
+        [
+          { 'identifier' => 'countries', 'content' => 'United Kingdom' }
+        ]
+      end
+
+      it 'returns countries content' do
+        expect(evidence_summary.countries).to eq('United Kingdom')
+      end
+    end
+
+    context 'when countries are not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.countries).to eq('')
+      end
+    end
+  end
+
+  describe '#topics' do
+    context 'when topics are present' do
+      let(:blocks) do
+        [
+          { 'identifier' => 'topics', 'content' => 'Topics 1' },
+          { 'identifier' => 'topics', 'content' => 'Topics 2' }
+        ]
+      end
+
+      it 'returns topics content' do
+        expect(evidence_summary.topics).to match_array(['Topics 1', 'Topics 2'])
+      end
+    end
+
+    context 'when topics are not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.topics).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9017-format-for-displaying) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

This is a dependency for [8773 TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights) and [8794 card]

## Context

Since the Mas cms client gemi s returning most of the fields in a block, I created a ruby class
on Fincap that organise the documents in a way for Fincap to use easily.

You can do with one document:

```
EvidenceSummary.new(document)
```

Or with many documents:

```
EvidenceSummary.map(Mas::Cms::Document.all)
```

This  new class is responsible for organising the fields that come from CMS in a way that represents the precise attributes to be used in evidence summaries.

Observations: 
I didn't add client groups and qualitative and quantitative yet because Is not part of the [8773 card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)
And I chose to use the word title instead of label. I find label a terrible name for it.