### PR TITLE
[DEV APPROVED] 9017 evidence hub summaries

### DIFF
--- a/app/controllers/evidence_hub_controller.rb
+++ b/app/controllers/evidence_hub_controller.rb
@@ -1,5 +1,5 @@
 class EvidenceHubController < ApplicationController
   def index
-    @documents = Mas::Cms::Document.all
+    @evidence_summaries = EvidenceSummary.map(Mas::Cms::Document.all)
   end
 end

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -11,8 +11,4 @@ class BasePresenter < SimpleDelegator
 
     super(@object)
   end
-
-  def h
-    @view
-  end
 end

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -1,0 +1,35 @@
+class EvidenceSummaryPresenter < BasePresenter
+  def link
+    h.link_to title, full_path
+  end
+
+  def evidence_type_info
+    h.t(
+      'evidence_hub.search_results.evidence_type',
+      evidence_type: evidence_type
+    )
+  end
+
+  def stripped_overview
+    h.strip_tags(overview)
+  end
+
+  def stripped_topics
+    all_topics = topics.map { |topic| h.strip_tags(topic).strip }.join(', ')
+    h.t('evidence_hub.search_results.topics', topics: all_topics)
+  end
+
+  def stripped_countries
+    h.t(
+      'evidence_hub.search_results.countries',
+      countries: h.strip_tags(countries)
+    )
+  end
+
+  def stripped_year_of_publication
+    h.t(
+      'evidence_hub.search_results.year_of_publication',
+      year_of_publication: h.strip_tags(year_of_publication)
+    )
+  end
+end

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -1,35 +1,35 @@
 class EvidenceSummaryPresenter < BasePresenter
   def link
-    h.link_to title, full_path
+    view.link_to title, full_path
   end
 
   def evidence_type_info
-    h.t(
+    view.t(
       'evidence_hub.search_results.evidence_type',
       evidence_type: evidence_type
     )
   end
 
   def stripped_overview
-    h.strip_tags(overview)
+    view.strip_tags(overview)
   end
 
   def stripped_topics
-    all_topics = topics.map { |topic| h.strip_tags(topic).strip }.join(', ')
-    h.t('evidence_hub.search_results.topics', topics: all_topics)
+    all_topics = topics.map { |topic| view.strip_tags(topic).strip }.join(', ')
+    view.t('evidence_hub.search_results.topics', topics: all_topics)
   end
 
   def stripped_countries
-    h.t(
+    view.t(
       'evidence_hub.search_results.countries',
-      countries: h.strip_tags(countries)
+      countries: view.strip_tags(countries)
     )
   end
 
   def stripped_year_of_publication
-    h.t(
+    view.t(
       'evidence_hub.search_results.year_of_publication',
-      year_of_publication: h.strip_tags(year_of_publication)
+      year_of_publication: view.strip_tags(year_of_publication)
     )
   end
 end

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -1,0 +1,25 @@
+<div class="l-constrained">
+  <div class="hero hero--blue">
+    <h1 class="hero__heading">
+      Evidence Summaries
+    </h1>
+  </div>
+
+  <div class="l-2col">
+    <div class="l-2col-side">
+      <div class="sidepanel">
+      </div>
+    </div>
+    <div class="l-2col-main">
+      <ul class="search-results">
+        <% @documents.each do |document| %>
+          <li class="search-results__item">
+            <p>
+              <%= link_to document.label, document.full_path %>
+            </p>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -1,7 +1,7 @@
 <div class="l-constrained">
   <div class="hero hero--blue">
     <h1 class="hero__heading">
-      Evidence Summaries
+      <%= t('evidence_hub.summaries.header') %>
     </h1>
   </div>
 
@@ -12,10 +12,25 @@
     </div>
     <div class="l-2col-main">
       <ul class="search-results">
-        <% @documents.each do |document| %>
+        <% present_collection(@evidence_summaries).each do |document| %>
           <li class="search-results__item">
-            <p>
-              <%= link_to document.label, document.full_path %>
+            <p class="search-results__title">
+              <%= document.link %>
+            </p>
+            <p class="search-results__description">
+              <%= document.stripped_overview %>
+            </p>
+            <p class="search-results__evidence-type">
+              <%= document.evidence_type_info %>
+            </p>
+            <p class="search-results__topics">
+              <%= document.stripped_topics %>
+            </p>
+            <p class="search-results__countries">
+              <%= document.stripped_countries %>
+            </p>
+            <p class="search-results__year-of-publication">
+              <%= document.stripped_year_of_publication %>
             </p>
           </li>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,9 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  evidence_hub:
+    summaries:
+      header: 'Evidence Summaries'
+    search_results:
+      evidence_type: 'Evidence type: %{evidence_type}'
+      countries: 'Country/Countries: %{countries}'
+      topics: 'Topics: %{topics}'
+      year_of_publication: 'Year of publication: %{year_of_publication}'

--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -1,0 +1,23 @@
+Feature: Evidence Hub Search
+	As a website user
+	In order to see the evidence in the hub
+	I want to be able to see a brief summary of all the insight summaries
+
+  Scenario: Visit the landing page
+    When I visit the evidence hub search page
+    Then I should see the "first" result as
+      | Field               | Value                                                    |
+      | document title      | Financial well-being: the employee view                  |
+      | overview            | Stress caused by pay levels, lack of financial awareness |
+      | evidence type       | Insight                                                  |
+      | topics              | Saving                                                   |
+      | countries           | United Kingdom                                           |
+      | year of publication | 2015                                                     |
+    And I should see the "second" result as
+      | Field               | Value                                                                              |
+      | document title      | Moving forward together: peer support for people with problem debt                 |
+      | overview            | Research has found that there remains a real stigma around seeking advice for debt |
+      | evidence type       | Insight                                                                            |
+      | topics              | Credit Use and Debt                                                                |
+      | countries           | England                                                                            |
+      | year of publication | 2017                                                                               |

--- a/features/step_definitions/evidence_hub/search_steps.rb
+++ b/features/step_definitions/evidence_hub/search_steps.rb
@@ -1,0 +1,12 @@
+When("I visit the evidence hub search page") do
+  evidence_summaries_page.load(locale: 'en')
+end
+
+Then("I should see the {string} result as") do |result_number, table|
+  search_result = evidence_summaries_page.search_results.send(result_number)
+
+  table.rows.each do |row|
+    field_name = row[0].parameterize.underscore
+    expect(search_result.send(field_name)).to have_text(row[1])
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,6 @@
 
 require 'cucumber/rails'
 require Rails.root.join('spec', 'support', 'vcr')
-
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.

--- a/features/support/ui/page.rb
+++ b/features/support/ui/page.rb
@@ -1,0 +1,6 @@
+require 'site_prism'
+
+module UI
+  class Page < SitePrism::Page
+  end
+end

--- a/features/support/ui/pages/evidence_summaries.rb
+++ b/features/support/ui/pages/evidence_summaries.rb
@@ -1,0 +1,18 @@
+require_relative '../page'
+
+module UI::Pages
+  class EvidenceSummaries < UI::Page
+    class SearchResult < SitePrism::Section
+      element :document_title, '.search-results__title'
+      element :evidence_type, '.search-results__evidence-type'
+      element :overview, '.search-results__description'
+      element :topics, '.search-results__topics'
+      element :countries, '.search-results__countries'
+      element :year_of_publication, '.search-results__year-of-publication'
+    end
+
+    set_url '{/locale}/evidence_hub'
+
+    sections :search_results, SearchResult, '.search-results li'
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -1,0 +1,19 @@
+module World
+  module Pages
+    def current_page
+      UI::Page.new
+    end
+
+    pages = %w[
+      evidence_summaries
+    ]
+
+    pages.each do |page|
+      define_method("#{page}_page") do
+        "UI::Pages::#{page.camelize}".constantize.new
+      end
+    end
+  end
+end
+
+World(World::Pages)

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe EvidenceSummaryPresenter do
+  let(:view) { ActionView::Base.new }
+  let(:evidence_summary) do
+    double('EvidenceSummary', attributes)
+  end
+  subject(:presenter) { described_class.new(evidence_summary, view) }
+
+  describe '#link' do
+    let(:attributes) do
+      {
+        title: 'Financial well-being: the employee view',
+        full_path: '/en/insights/financial-well-being-the-employee-view'
+      }
+    end
+
+    it 'returns link with title and full path' do
+      expect(presenter.link).to include(
+        '<a href="/en/insights/financial-well-being-the-employee-view">'
+      )
+      expect(presenter.link).to include(
+        'Financial well-being: the employee view</a>'
+      )
+    end
+  end
+
+  describe '#evidence_type_info' do
+    let(:attributes) do
+      {
+        evidence_type: 'Insight'
+      }
+    end
+
+    it 'returns the evidence type of the document' do
+      expect(presenter.evidence_type_info).to eq('Evidence type: Insight')
+    end
+  end
+
+  describe '#stripped_overview' do
+    let(:attributes) do
+      {
+        overview: '<p>Nationally representative survey</p>'
+      }
+    end
+
+    it 'strips all html tags from overview' do
+      expect(presenter.stripped_overview).to eq(
+        'Nationally representative survey'
+      )
+    end
+  end
+
+  describe '#stripped_topics' do
+    let(:attributes) do
+      {
+        topics: ['<p>Saving</p>', '<p>Financial Capability</p>']
+      }
+    end
+
+    it 'strips all html tags from topics' do
+      expect(presenter.stripped_topics).to eq(
+        'Topics: Saving, Financial Capability'
+      )
+    end
+  end
+
+  describe '#stripped_countries' do
+    let(:attributes) do
+      {
+        countries: '<p>United Kingdom</p>'
+      }
+    end
+
+    it 'strips all html tags from countries' do
+      expect(presenter.stripped_countries).to eq(
+        'Country/Countries: United Kingdom'
+      )
+    end
+  end
+
+  describe '#stripped_year_of_publication' do
+    let(:attributes) do
+      {
+        year_of_publication: '<p>2017</p>'
+      }
+    end
+
+    it 'strips all html tags from year of publication' do
+      expect(presenter.stripped_year_of_publication).to eq(
+        'Year of publication: 2017'
+      )
+    end
+  end
+end


### PR DESCRIPTION
[TP task](https://moneyadviceservice.tpondemand.com/entity/9017-format-for-displaying) from [TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights)

This is a dependency for [8773 TP card](https://moneyadviceservice.tpondemand.com/entity/8773-evhub-resultssearch-page-insights) and [8794 card]

Please review #45 first so that I can base this PR on master.

## Context

This is the work of rendering the search results for the first time when the user enter the evidence hub page.

## Next PRs

- [x] Open a PR on mas-cms-client which accepts to pass the document_type as params for the all call.
- [x] Pass the "insight" as "document_type" on the Document.all call to CMS on fincap repo.

## Observations: 

* This task is not the frontend part (even if I choose to use the styleguide) so I will not post here a screenshot of the page.
* On the presenter I prefer to maintain the I18n.t call using the same locale over and over ('evidence_hub.search_results.evidence_type') because on the other 8794 I need to re-use so that would be the **best time** to refactor this presenter.
* On the evidence_hub_search.feature I choose the name for the title field as 'document title' because 'title' is an internal method of Site prism that could cause odd behaviours.