### PR TITLE
[DEV APPROVED] - 9033 add dough components to nav

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,8 +16,7 @@
 //= require jquery
 //= require turbolinks
 
-require(['Nav'],
-  function (Nav) {
-    new Nav($('.nav')).init();
-  }
-);
+// Component Loader
+require(['jquery', 'componentLoader'], function ($, componentLoader) {
+  componentLoader.init($('body'));
+});

--- a/app/assets/javascripts/components/Nav.js
+++ b/app/assets/javascripts/components/Nav.js
@@ -1,4 +1,4 @@
-define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseComponent, utilities) {
   'use strict';
 
   var Nav,
@@ -48,8 +48,8 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   Nav.prototype._setUpComponent = function() {
     this.$nav.removeClass('uninitialised');
 
-    $(window).on('resize', this._debounce(this._setUpMobileAnimation.bind(this), 100));
-    $(window).on('resize', this._debounce(this._getViewportSize.bind(this), 99));
+    $(window).on('resize', utilities.debounce(this._setUpMobileAnimation.bind(this), 100));
+    $(window).on('resize', utilities.debounce(this._getViewportSize.bind(this), 99));
   };
 
   Nav.prototype._getViewportSize = function() {
@@ -282,27 +282,6 @@ define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
       e.preventDefault();
       callback.call(context, this);
     });
-  }
-
-  /**
-   * Rate limit the amount of times a method is called
-   * @param  {function} func Function to be called
-   * @param  {Number} wait How long to wait until func is called in milliseconds
-   * @return {function}
-   */
-  Nav.prototype._debounce = function(func, wait) {
-    var timeout;
-
-    return function() {
-      var context = this,
-          args = arguments,
-          later = function() {
-            timeout = null;
-            func.apply(context, args);
-          };
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-    };
   }
 
   return Nav;

--- a/app/assets/javascripts/components/Nav.js
+++ b/app/assets/javascripts/components/Nav.js
@@ -1,7 +1,12 @@
-define(['jquery'], function($) {
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
   'use strict';
 
-  var Nav = function($el) {
+  var Nav,
+      defaultConfig = {};
+
+  Nav = function($el, config) {
+    Nav.baseConstructor.call(this, $el, config, defaultConfig);
+
     this.smallViewport = 720;
     this.delay = 250;
     this.$mobileNavButton = $(document).find('[data-mobile-nav-button]');
@@ -18,6 +23,13 @@ define(['jquery'], function($) {
     this.$mobileNavClose = this.$nav.find('[data-mobile-nav-close]');
     this.$searchBar = this.$nav.find('[data-nav-search-bar]');
   };
+
+  /**
+  * Inherit from base module, for shared methods and interface
+  */
+  DoughBaseComponent.extend(Nav);
+
+  Nav.componentName = 'Nav';
 
   /**
   * Initialize the component

--- a/app/assets/javascripts/components/Nav.js
+++ b/app/assets/javascripts/components/Nav.js
@@ -33,7 +33,8 @@ define(['jquery', 'DoughBaseComponent', 'utilities', 'mediaQueries'], function($
   /**
   * Initialize the component
   */
-  Nav.prototype.init = function() {
+  Nav.prototype.init = function(initialised) {
+    this._initialisedSuccess(initialised);
     this._setUpComponent();
     this._getViewportSize();
     this._setUpMobileAnimation();

--- a/app/assets/javascripts/components/Nav.js
+++ b/app/assets/javascripts/components/Nav.js
@@ -1,4 +1,4 @@
-define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseComponent, utilities) {
+define(['jquery', 'DoughBaseComponent', 'utilities', 'mediaQueries'], function($, DoughBaseComponent, utilities, mediaQueries) {
   'use strict';
 
   var Nav,
@@ -7,7 +7,6 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
   Nav = function($el, config) {
     Nav.baseConstructor.call(this, $el, config, defaultConfig);
 
-    this.smallViewport = 720;
     this.delay = 250;
     this.$mobileNavButton = $(document).find('[data-mobile-nav-button]');
     this.$mobileNavOverlay = $(document).find('[data-mobile-nav-overlay]');
@@ -53,7 +52,7 @@ define(['jquery', 'DoughBaseComponent', 'utilities'], function($, DoughBaseCompo
   };
 
   Nav.prototype._getViewportSize = function() {
-    if ($(window).width() < this.smallViewport) {
+    if (mediaQueries.atSmallViewport()) {
       this.atSmallViewport = true;
     } else {
       this.atSmallViewport = false;

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -1,4 +1,5 @@
 //= depend_on_asset components/Nav
+//= depend_on_asset dough/assets/js/lib/featureDetect
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
 
 <%
@@ -10,6 +11,11 @@
     baseUrl: (Rails.application.config.action_controller.asset_host || '') + \
       Rails.application.config.assets.prefix,
     paths: {
+      # External dependancies
+      eventsWithPromises: requirejs_path('eventsWithPromises/src/eventsWithPromises'),
+      jqueryThrottleDebounce: requirejs_path('jqueryThrottleDebounce/jquery.ba-throttle-debounce'),
+      rsvp: requirejs_path('rsvp/rsvp'),
+
       # Components
       Nav: requirejs_path('components/Nav')
     }
@@ -18,7 +24,9 @@
   # Dough
   requirejs_config[:paths].merge!({
     utilities: requirejs_path('dough/assets/js/lib/utilities'),
-    DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent')
+    DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
+    featureDetect: requirejs_path('dough/assets/js/lib/featureDetect'),
+    mediaQueries: requirejs_path('dough/assets/js/lib/mediaQueries')
   })
 %>
 

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -1,4 +1,5 @@
 //= depend_on_asset components/Nav
+//= depend_on_asset dough/assets/js/components/DoughBaseComponent
 
 <%
   def requirejs_path(asset)
@@ -13,6 +14,12 @@
       Nav: requirejs_path('components/Nav')
     }
   }
+
+  # Dough
+  requirejs_config[:paths].merge!({
+    utilities: requirejs_path('dough/assets/js/lib/utilities'),
+    DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent')
+  })
 %>
 
 // RequireJS config

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -1,6 +1,8 @@
-//= depend_on_asset components/Nav
-//= depend_on_asset dough/assets/js/lib/featureDetect
+//= depend_on_asset rsvp/rsvp
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
+//= depend_on_asset dough/assets/js/lib/componentLoader
+//= depend_on_asset dough/assets/js/lib/featureDetect
+//= depend_on_asset components/Nav
 
 <%
   def requirejs_path(asset)
@@ -25,6 +27,7 @@
   requirejs_config[:paths].merge!({
     utilities: requirejs_path('dough/assets/js/lib/utilities'),
     DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
+    componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
     featureDetect: requirejs_path('dough/assets/js/lib/featureDetect'),
     mediaQueries: requirejs_path('dough/assets/js/lib/mediaQueries')
   })

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,8 +1,8 @@
 <a data-mobile-nav-button href="#" role="button" class="mobile-nav-button">Menu</a>
 
-<nav class="nav uninitialised"> <!-- is-active -->
+<nav class="nav uninitialised" data-dough-component="Nav">
   <div class="l-constrained">
-    <ul class="nav__level-1" data-nav-level-1> <!-- is-active is-open -->
+    <ul class="nav__level-1" data-nav-level-1>
       <li class="nav__level-1__element" data-nav-level-1-item>
         <a href="#" class="nav__level-1__element__heading" data-nav-level-1-heading>
           <span class="nav__level-1__element__text">What is financial capability?</span>
@@ -159,7 +159,7 @@
         </div>
       </li>
 
-      <li class="nav__level-1__element" data-nav-level-1-item> <!-- is-active -->
+      <li class="nav__level-1__element" data-nav-level-1-item>
         <a href="#" class="nav__level-1__element__heading" data-nav-level-1-heading>
           <span class="nav__level-1__element__text">Life stages</span>
           <svg xmlns="http://www.w3.org/2000/svg" class="nav__arrow" focusable="false">
@@ -187,7 +187,7 @@
                   </svg>
                 </a>
 
-                <div class="nav__level-3" data-nav-level-3> <!-- is-active -->
+                <div class="nav__level-3" data-nav-level-3>
                   <div class="l-constrained">
                     <div class="nav__level-3__image"></div>
 


### PR DESCRIPTION
[TP9040](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9040&appConfig=eyJhY2lkIjoiOThBNEI1MURGODY0REREODQ4Qjk2MkE1RUY4NTRBMTIifQ==)

This PR adds some Common Dough components to the basic Nav (along with some other components required by these), specifically: 
- componentLoader: loads this and any other components where required on page load
- DoughBaseComponent: initialises the component
- utilities: used by the Nav to implement the Dough debounce utility
- mediaQueries: used by the Nav to implement the Dough atSmallViewport utility
