### PR TITLE
Update dough to 5.27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.4.1'
 
 gem 'rails', '~> 5.0.6'
 
-gem 'dough-ruby', '~> 5.26'
+gem 'dough-ruby', '~> 5.27'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
 gem 'mas-cms-client', '1.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,11 @@ GEM
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
+    dough-ruby (5.27.0.305)
+      activemodel
+      activesupport
+      rails (>= 3.2, <= 5.0.6)
+      sass-rails
     erubis (2.7.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -277,6 +282,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   dotenv-rails
+  dough-ruby (~> 5.27)
   factory_bot_rails
   jbuilder (~> 2.5)
   jquery-rails


### PR DESCRIPTION
**No TP cards**.

## Context

The master was failing because Dough was added without compatibility with Rails 5. 

[Dough 5.27 version](https://github.com/moneyadviceservice/dough/pull/300) adds Rails 5 compatibility, which fixes the compatibility error when you run `bundle install`