### PR TITLE
Adds 3 column layout example to styleguide

### DIFF
--- a/app/views/styleguide/layout.html.erb
+++ b/app/views/styleguide/layout.html.erb
@@ -111,3 +111,25 @@
     </div>
   </div>
 </xmp>
+
+<h3 class="styleguide__subheading">3 columns even</h3>
+<div class="l-constrained">
+  <div class="styleguide__example">
+    <% 3.times do %>
+      <div class="l-3col-even">
+        <h3>1/3</h3>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <div class="l-constrained">
+    <% 3.times do %>
+      <div class="l-3col-even">
+        <h3>1/3</h3>
+      </div>
+    <% end %>
+  </div>
+</xmp>


### PR DESCRIPTION
# Adds 3 column layout to styleguide

This PR adds the 3 column layout example to the styleguide

| Screenshot |
|------------|
|![image](https://user-images.githubusercontent.com/13165846/37210340-4e9e4f98-23a0-11e8-90a3-ffc8f2a640be.png)|
