### PR TITLE
[DEV APPROVED] 8794 Make evidence summary presenter more robust for Insight page

### DIFF
--- a/app/models/evidence_summary.rb
+++ b/app/models/evidence_summary.rb
@@ -1,4 +1,6 @@
 class EvidenceSummary
+  extend ActiveModel::Translation
+
   def self.map(documents)
     documents.map { |document| new(document) }
   end
@@ -13,6 +15,14 @@ class EvidenceSummary
 
   def initialize(document)
     @document = document
+  end
+
+  def content
+    find_block(:content)
+  end
+
+  def client_group
+    find_blocks(:client_groups)
   end
 
   def topics

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -3,33 +3,73 @@ class EvidenceSummaryPresenter < BasePresenter
     view.link_to title, full_path
   end
 
-  def evidence_type_info
-    view.t(
-      'evidence_hub.search_results.evidence_type',
-      evidence_type: evidence_type
-    )
+  def evidence_type_field_name
+    translate_field(:evidence_type)
+  end
+
+  def topics_field_name
+    translate_field(:topics)
+  end
+
+  def countries_field_name
+    translate_field(:countries)
+  end
+
+  def year_of_publication_field_name
+    translate_field(:year_of_publication)
+  end
+
+  def client_group_field_name
+    translate_field(:client_group)
+  end
+
+  def formatted_evidence_type
+    "#{evidence_type_field_name}: #{evidence_type}"
+  end
+
+  def formatted_topics
+    "#{topics_field_name}: #{stripped_topics.join(', ')}"
+  end
+
+  def formatted_countries
+    "#{countries_field_name}: #{stripped_countries}"
+  end
+
+  def formatted_year_of_publication
+    "#{year_of_publication_field_name}: #{stripped_year_of_publication}"
   end
 
   def stripped_overview
-    view.strip_tags(overview)
+    strip_text(overview)
+  end
+
+  def stripped_client_group
+    strip_collection(client_group)
   end
 
   def stripped_topics
-    all_topics = topics.map { |topic| view.strip_tags(topic).strip }.join(', ')
-    view.t('evidence_hub.search_results.topics', topics: all_topics)
-  end
-
-  def stripped_countries
-    view.t(
-      'evidence_hub.search_results.countries',
-      countries: view.strip_tags(countries)
-    )
+    strip_collection(topics)
   end
 
   def stripped_year_of_publication
-    view.t(
-      'evidence_hub.search_results.year_of_publication',
-      year_of_publication: view.strip_tags(year_of_publication)
-    )
+    strip_text(year_of_publication)
+  end
+
+  def stripped_countries
+    strip_text(countries)
+  end
+
+  private
+
+  def translate_field(field)
+    object.class.human_attribute_name(field)
+  end
+
+  def strip_collection(collection)
+    collection.map { |element| strip_text(element) }
+  end
+
+  def strip_text(text)
+    view.strip_tags(text)
   end
 end

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -21,16 +21,16 @@
               <%= document.stripped_overview %>
             </p>
             <p class="search-results__evidence-type">
-              <%= document.evidence_type_info %>
+              <%= document.formatted_evidence_type %>
             </p>
             <p class="search-results__topics">
-              <%= document.stripped_topics %>
+              <%= document.formatted_topics %>
             </p>
             <p class="search-results__countries">
-              <%= document.stripped_countries %>
+              <%= document.formatted_countries %>
             </p>
             <p class="search-results__year-of-publication">
-              <%= document.stripped_year_of_publication %>
+              <%= document.formatted_year_of_publication %>
             </p>
           </li>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,9 +1,16 @@
 en:
+  activemodel:
+    attributes:
+      evidence_summary:
+        evidence_type: 'Evidence type'
+        countries: 'Country/Countries'
+        topics: 'Topics'
+        year_of_publication: 'Year of publication'
+        client_group: 'Client group'
   evidence_hub:
     summaries:
       header: 'Evidence Summaries'
-    search_results:
-      evidence_type: 'Evidence type: %{evidence_type}'
-      countries: 'Country/Countries: %{countries}'
-      topics: 'Topics: %{topics}'
-      year_of_publication: 'Year of publication: %{year_of_publication}'
+  fincap:
+    evidence_hub:
+      insight_summary:
+        name: 'Insight'

--- a/spec/models/evidence_summary_spec.rb
+++ b/spec/models/evidence_summary_spec.rb
@@ -14,6 +14,23 @@ RSpec.describe EvidenceSummary do
     end
   end
 
+  describe '#content' do
+    let(:attributes) do
+      {
+        'blocks' => [
+          {
+            'identifier' => 'content',
+            'content' => 'Stress caused by pay levels ...'
+          }
+        ]
+      }
+    end
+
+    it 'returns the content value for block content identifier' do
+      expect(evidence_summary.content).to eq('Stress caused by pay levels ...')
+    end
+  end
+
   describe '#evidence_type' do
     context 'when layout identifier is present' do
       let(:attributes) { { 'layout_identifier' => 'insight' } }
@@ -86,6 +103,29 @@ RSpec.describe EvidenceSummary do
     context 'when countries are not present' do
       it 'returns empty content' do
         expect(evidence_summary.countries).to eq('')
+      end
+    end
+  end
+
+  describe '#client_group' do
+    context 'when client groups are present' do
+      let(:blocks) do
+        [
+          { 'identifier' => 'client_groups', 'content' => 'Older people' },
+          { 'identifier' => 'client_groups', 'content' => 'Working age' }
+        ]
+      end
+
+      it 'returns client groups content' do
+        expect(evidence_summary.client_group).to match_array(
+          ['Older people', 'Working age']
+        )
+      end
+    end
+
+    context 'when client groups are not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.client_group).to be_empty
       end
     end
   end

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe EvidenceSummaryPresenter do
     double('EvidenceSummary', attributes)
   end
   subject(:presenter) { described_class.new(evidence_summary, view) }
+  let(:attributes) { {} }
+
+  before do
+    allow(evidence_summary).to receive(:class).and_return(EvidenceSummary)
+  end
 
   describe '#link' do
     let(:attributes) do
@@ -23,7 +28,39 @@ RSpec.describe EvidenceSummaryPresenter do
     end
   end
 
-  describe '#evidence_type_info' do
+  describe '#client_group_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.client_group_field_name).to eq('Client group')
+    end
+  end
+
+  describe '#evidence_type_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.evidence_type_field_name).to eq('Evidence type')
+    end
+  end
+
+  describe '#topics_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.topics_field_name).to eq('Topics')
+    end
+  end
+
+  describe '#year_of_publication_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.year_of_publication_field_name).to eq(
+        'Year of publication'
+      )
+    end
+  end
+
+  describe '#countries_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.countries_field_name).to eq('Country/Countries')
+    end
+  end
+
+  describe '#formatted_evidence_type' do
     let(:attributes) do
       {
         evidence_type: 'Insight'
@@ -31,7 +68,49 @@ RSpec.describe EvidenceSummaryPresenter do
     end
 
     it 'returns the evidence type of the document' do
-      expect(presenter.evidence_type_info).to eq('Evidence type: Insight')
+      expect(presenter.formatted_evidence_type).to eq('Evidence type: Insight')
+    end
+  end
+
+  describe '#formatted_topics' do
+    let(:attributes) do
+      {
+        topics: ['One topic', 'Another topic']
+      }
+    end
+
+    it 'returns the topics separated by comma' do
+      expect(presenter.formatted_topics).to eq(
+        'Topics: One topic, Another topic'
+      )
+    end
+  end
+
+  describe '#formatted_countries' do
+    let(:attributes) do
+      {
+        countries: 'United Kingdom'
+      }
+    end
+
+    it 'returns the countries with the field name' do
+      expect(presenter.formatted_countries).to eq(
+        'Country/Countries: United Kingdom'
+      )
+    end
+  end
+
+  describe '#formatted_year_of_publication' do
+    let(:attributes) do
+      {
+        year_of_publication: '2017'
+      }
+    end
+
+    it 'returns the evidence type of the document' do
+      expect(presenter.formatted_year_of_publication).to eq(
+        'Year of publication: 2017'
+      )
     end
   end
 
@@ -49,6 +128,19 @@ RSpec.describe EvidenceSummaryPresenter do
     end
   end
 
+  describe '#stripped_client_group' do
+    let(:attributes) do
+      {
+        client_group: ['<p>Working age</p>', '<p>Older people</p>']
+      }
+    end
+
+    it 'strips all html tags from client groups' do
+      expect(presenter.stripped_client_group).to eq(
+        ['Working age', 'Older people']
+      )
+    end
+  end
   describe '#stripped_topics' do
     let(:attributes) do
       {
@@ -58,7 +150,7 @@ RSpec.describe EvidenceSummaryPresenter do
 
     it 'strips all html tags from topics' do
       expect(presenter.stripped_topics).to eq(
-        'Topics: Saving, Financial Capability'
+        ['Saving', 'Financial Capability']
       )
     end
   end
@@ -72,7 +164,7 @@ RSpec.describe EvidenceSummaryPresenter do
 
     it 'strips all html tags from countries' do
       expect(presenter.stripped_countries).to eq(
-        'Country/Countries: United Kingdom'
+        'United Kingdom'
       )
     end
   end
@@ -86,7 +178,7 @@ RSpec.describe EvidenceSummaryPresenter do
 
     it 'strips all html tags from year of publication' do
       expect(presenter.stripped_year_of_publication).to eq(
-        'Year of publication: 2017'
+        '2017'
       )
     end
   end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/8794)

# Context

So now the evidence summary presenter will support both evidence summaries
page and the insight summary page because they are very similar.

The index page has this formatted:

%{Field Name}: #{Field value}

But the show action has:

%{Field Name}
  %{Element one}
  %{Element two}

in different ways. So in this line of thought I separated into three main methods

* The field name to be displayed. Used on the index and to be used in the show page. For this I added the I18n active model module so can help on this.
* The format of Field Name: field value that is used on index page
* Separated the strip tags for both index and show pages
