### PR TITLE
[DEV APPROVED] - 8794 add links and contact information

### DIFF
--- a/app/models/evidence_summary.rb
+++ b/app/models/evidence_summary.rb
@@ -45,6 +45,14 @@ class EvidenceSummary
     find_block(:year_of_publication)
   end
 
+  def links_to_research
+    find_block(:links_to_research)
+  end
+
+  def contact_information
+    find_block(:contact_information)
+  end
+
   private
 
   def find_blocks(block_identifier)

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -27,6 +27,14 @@ class EvidenceSummaryPresenter < BasePresenter
     "#{evidence_type_field_name}:"
   end
 
+  def contact_information_field_name
+    translate_field(:contact_information)
+  end
+
+  def links_to_research_field_name
+    translate_field(:links_to_research)
+  end
+
   def formatted_topics
     "#{topics_field_name}: #{stripped_topics.join(', ')}"
   end

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -7,15 +7,17 @@
     </div>
   </div>
 
-  <div class="l-2col">
-    <div class="l-2col-side">
-      <div class="sidepanel">
-        <h4 class="sidepanel__title">Keyword search</h4>
+  <div class="row">
+    <div class="l-2col">
+      <div class="l-2col-side">
+        <div class="sidepanel">
+          <h4 class="sidepanel__title">Keyword search</h4>
 
-        <%= form_tag(evidence_hub_index_path, method: :get) do %>
-          <%= text_field_tag :keyword, params[:keyword] %>
-          <%= button_tag 'Save', type: 'submit', class: 'btn btn--primary btn--full-width' %>
-        <% end %>
+          <%= form_tag(evidence_hub_index_path, method: :get) do %>
+            <%= text_field_tag :keyword, params[:keyword] %>
+            <%= button_tag 'Save', type: 'submit', class: 'btn btn--primary btn--full-width' %>
+          <% end %>
+        </div>
       </div>
       <div class="l-2col-main">
         <ul class="search-results">

--- a/app/views/insights/show.html.erb
+++ b/app/views/insights/show.html.erb
@@ -59,6 +59,25 @@
               <%= evidence_summary.stripped_countries %>
             </div>
           </div>
+          <div class="sidepanel">
+            <div class="evidence-hub__links">
+              <h5 class="sidepanel__subtitle">
+                <%= evidence_summary.links_to_research_field_name %>
+              </h5>
+
+              <%= evidence_summary.links_to_research.html_safe %>
+            </div>
+          </div>
+
+          <div class="sidepanel">
+            <div class="evidence-hub__contact_information">
+              <h5 class="sidepanel__subtitle">
+                <%= evidence_summary.contact_information_field_name %>
+              </h5>
+
+              <%= evidence_summary.contact_information.html_safe %>
+            </div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,8 @@ en:
         topics: 'Topics'
         year_of_publication: 'Year of publication'
         client_group: 'Client group'
+        contact_information: 'Contact information'
+        links_to_research: 'Links to further information'
   evidence_hub:
     summaries:
       header: 'Evidence Summaries'

--- a/features/insight_summary_page.feature
+++ b/features/insight_summary_page.feature
@@ -14,3 +14,5 @@ Feature: Evidence Hub: Insight Summary page
       | Topics              | Saving                                                   |
       | Year of publication | 2015                                                     |
       | Country             | United Kingdom                                           |
+      | Contact information | MASPD (in partnership with Company S.A)                  |
+      | Links               | Financial well-being: the employee view - full report    |

--- a/features/support/ui/pages/evidence_summary.rb
+++ b/features/support/ui/pages/evidence_summary.rb
@@ -9,6 +9,8 @@ module UI
       element :topics, '.evidence-hub__topics'
       element :year_of_publication, '.evidence-hub__year_of_publication'
       element :country, '.evidence-hub__country'
+      element :contact_information, '.evidence-hub__contact_information'
+      element :links, '.evidence-hub__links'
     end
   end
 end

--- a/spec/models/evidence_summary_spec.rb
+++ b/spec/models/evidence_summary_spec.rb
@@ -47,6 +47,51 @@ RSpec.describe EvidenceSummary do
     end
   end
 
+  describe '#links_to_research' do
+    context 'when links are present' do
+      let(:blocks) do
+        [
+          {
+            'identifier' => 'links_to_research',
+            'content' => '<a>Some link</a>'
+          }
+        ]
+      end
+
+      it 'returns links content' do
+        expect(evidence_summary.links_to_research).to eq('<a>Some link</a>')
+      end
+    end
+
+    context 'when links are not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.links_to_research).to eq('')
+      end
+    end
+  end
+
+  describe '#contact_information' do
+    context 'when contact is present' do
+      let(:blocks) do
+        [
+          {
+            'identifier' => 'contact_information',
+            'content' => 'Tel: 7070707070'
+          }
+        ]
+      end
+
+      it 'returns contact information content' do
+        expect(evidence_summary.contact_information).to eq('Tel: 7070707070')
+      end
+    end
+
+    context 'when contact is not present' do
+      it 'returns empty content' do
+        expect(evidence_summary.contact_information).to eq('')
+      end
+    end
+  end
   describe '#overview' do
     context 'when overview is present' do
       let(:blocks) do

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe EvidenceSummaryPresenter do
     end
   end
 
+  describe '#contact_information_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.contact_information_field_name).to eq(
+        'Contact information'
+      )
+    end
+  end
+
+  describe '#links_to_research_field_name' do
+    it 'returns the name of the field' do
+      expect(presenter.links_to_research_field_name).to eq(
+        'Links to further information'
+      )
+    end
+  end
+
   describe '#countries_field_name' do
     it 'returns the name of the field' do
       expect(presenter.countries_field_name).to eq('Country/Countries')


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/8794)

# Context

So this PR adds the two sidepanel boxes for the insight page: the links to further information and contact details.

Obs.: There are three commits on this PR because it is waiting the PRs #60 and #59 to be merged first. After this two are merged there will be only one commit on this PR.

