### PR TITLE
9079 - Adds new label UI helper

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -2,9 +2,9 @@ $responsive: true;
 
 @import 'lib/all';
 @import 'layout/all';
-@import 'helpers/all';
 @import 'layout/common/all';
 @import 'base/all';
+@import 'helpers/all';
 @import 'components/all';
 @import 'page_specific/all';
 @import 'components/ui/all';

--- a/app/assets/stylesheets/components/ui/_search_results.scss
+++ b/app/assets/stylesheets/components/ui/_search_results.scss
@@ -16,19 +16,12 @@
 }
 
 .search-results__item--new {
+  @extend .is-new;
+  
   &:after {
-    @include body(12, 20);
-    @extend %border-radius;
-    content: 'new';
-    text-transform: uppercase;
     position: absolute;
     right: $baseline-unit;
     top: $baseline-unit;
-    margin-left: $baseline-unit;
-    color: $color-white;
-    background-color: $primary-blue;
-    padding: $baseline-unit/2 $baseline-unit;
-    font-weight: 500;
   }
 }
 

--- a/app/assets/stylesheets/helpers/_all.scss
+++ b/app/assets/stylesheets/helpers/_all.scss
@@ -2,3 +2,4 @@
 @import 'inline_block';
 @import 'border';
 @import 'visually_hidden';
+@import 'new';

--- a/app/assets/stylesheets/helpers/_new.scss
+++ b/app/assets/stylesheets/helpers/_new.scss
@@ -1,0 +1,15 @@
+.is-new {
+  &:after {
+    @extend %border-radius;
+    @include body(14, 18);
+    content: 'new';
+    text-transform: uppercase;
+    margin-left: $baseline-unit;
+    color: $color-white;
+    background-color: $primary-blue;
+    padding: $baseline-unit/2 $baseline-unit;
+    font-weight: 500;
+    display: inline-block;
+    vertical-align: $baseline-unit;
+  }
+}

--- a/app/assets/stylesheets/page_specific/_styleguide.scss
+++ b/app/assets/stylesheets/page_specific/_styleguide.scss
@@ -209,3 +209,9 @@ a.styleguide__anchor {
     display: none;
   }
 }
+
+.heading--new {
+  &:after {
+    @extend .is-new;
+  }
+}

--- a/app/controllers/styleguide_controller.rb
+++ b/app/controllers/styleguide_controller.rb
@@ -1,5 +1,5 @@
 class StyleguideController < ApplicationController
-  before_action :components, :page_specific, :links
+  before_action :components, :page_specific, :ui_helpers, :links
   layout 'styleguide'
   include StyleguideHelper
 
@@ -45,6 +45,10 @@ class StyleguideController < ApplicationController
 
   def page_specific
     @page_specific = PAGE_SPECIFIC
+  end
+
+  def ui_helpers
+    @ui_helpers = UI_HELPERS
   end
 
   def links

--- a/app/helpers/styleguide_helper.rb
+++ b/app/helpers/styleguide_helper.rb
@@ -46,5 +46,9 @@ module StyleguideHelper
     'Search Results' => 'search_results'
   }.freeze
 
+  UI_HELPERS = {
+    '"New" Label' => 'new_label'
+  }.freeze
+
   LINKS = %w[Layout Typography Links Lists Colours Buttons Forms].freeze
 end

--- a/app/views/styleguide/_menu.html.erb
+++ b/app/views/styleguide/_menu.html.erb
@@ -24,3 +24,12 @@
     </li>
   <% end %>
 </ul>
+
+<ul class="styleguide-nav">
+  <li class="styleguide-nav__title">UI Helpers<li>
+  <%- @ui_helpers.each do |label, path| %>
+    <li class="styleguide-nav__item">
+      <a href=<%= "/styleguide/#{path}" %> class="styleguide-nav__item-link"><%= label %></a>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/styleguide/new_label.html.erb
+++ b/app/views/styleguide/new_label.html.erb
@@ -1,0 +1,26 @@
+<h1>UI Helpers</h1>
+<h2>New Label</h2>
+<h3 class="styleguide__subheading">Using .is-new</h3>
+<div class="styleguide__example">
+  <h2 class="is-new">Adding a new label</h2>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <h2 class="is-new">Adding a new label</h2>
+</xmp>
+<p>You can also add more specific styles and extend .is-new to include the new label (See <a href="/styleguide/search_results" target="_blank">Search Results</a>) </p>
+<h3 class="styleguide__subheading">Extending .is-new</h3>
+<div class="styleguide__example">
+  <h2 class="heading heading--new">Adding a new label</h2>
+</div>
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  // Markup
+  <h2 class="heading heading--new">Adding a new label</h2>
+
+  // SASS
+  .heading--new {
+    @extend .is-new;
+    // Additional styles
+  }
+</xmp>


### PR DESCRIPTION
# Adds "NEW" label UI helper

This PR adds a new UI helper to the styleguide, this is utilized by either:

**Using the class directly on the element**
```
<h2 class="is-new">Heading</h2>
```

**Extending the class for custom styles**
```
// Markup
<h2 class="heading heading--is-new">Heading</h2>

// SASS
.heading--is-new {
  @extend .is-new;
  // additional styles
}
```

| Screenshot |
|-------------|
|![image](https://user-images.githubusercontent.com/13165846/37333380-1e6e5986-26a1-11e8-88f1-ef35155176b6.png)|
