### PR TITLE
Remove test script from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./script/test
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
The test script was defined in the docker-compose.yml and in the Jenkinsfile test stage.  Two instances of the test script were therefore executed during the Jenkins job causing the following rake error;

`rails aborted!
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "pg_database_datname_index"
DETAIL:  Key (datname)=(fin_cap_test) already exists.`