### PR TITLE
[DEV APPROVED] - Adds the evaluation types ui component to search results

### DIFF
--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -31,9 +31,7 @@
               </p>
               <p class="search-results__evidence-type">
                 <%= document.formatted_evidence_type_label %>
-                <a href="#" class="search-results__evidence-type-link">
-                  <%= document.evidence_type %>
-                </a>
+                <%= render 'shared/evaluation_types', type: "#{document.evidence_type}" %>
               </p>
               <p class="search-results__topics">
                 <%= document.formatted_topics %>


### PR DESCRIPTION
# Adds the evaluation types ui component to search results

Applies the evaluation types ui component to the search results (see: /styleguide/evaluation_types)

| Screenshot |
|-------------|
|![image](https://user-images.githubusercontent.com/13165846/37762753-239cc7e2-2db5-11e8-96a9-0d40a205626f.png)|
