### PR TITLE
[DEV APPROVED] Removes turbolinks from fincap project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'mas-cms-client', '1.10.0'
 gem 'newrelic_rpm'
 gem 'pg', '~> 0.18'
 gem 'sass-rails', '~> 5.0'
-gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require require_config
 //= require lib/modernizr-custom
 //= require jquery
-//= require turbolinks
 
 // Component Loader
 require(['jquery', 'componentLoader'], function ($, componentLoader) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,8 @@
     <title>FinCap</title>
     <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
 
     <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
       <%= render 'shared/svg/icon_sprite' %>

--- a/app/views/layouts/styleguide.html.erb
+++ b/app/views/layouts/styleguide.html.erb
@@ -4,8 +4,8 @@
     <title>FinCap Styleguide</title>
     <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
 
     <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
       <%= render 'shared/svg/icon_sprite' %>


### PR DESCRIPTION
# Removes turbolinks from fincap project

This PR removes turbolinks from the fincap project.  Turbolinks never call the documents ready event, causing problems for some of our JS components implemented via the dough component loader.

Basically we'd find that components won't kick in until the page is refreshed by the user.