### PR TITLE
[DEV APPROVED] DRYs up the large cta by moving markup into a partial

### DIFF
--- a/app/views/shared/_large_cta.html.erb
+++ b/app/views/shared/_large_cta.html.erb
@@ -1,0 +1,6 @@
+<a href=<%= url %> class="large-cta">
+  <svg xmlns="http://www.w3.org/2000/svg" class="large-cta__icon svg-icon svg-icon--<%= "#{icon}" %>" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--<%= "#{icon}" %>"></use>
+  </svg>
+  <span class="large-cta__text"><%= text %></span>
+</a>

--- a/app/views/styleguide/largecta.html.erb
+++ b/app/views/styleguide/largecta.html.erb
@@ -1,12 +1,16 @@
 <h1>Large Call to Action</h1>
+<p>Developer notes: This component uses a partial view for the link url, icon and text which expects values.</p>
+<p>To render in the view, call the partial from "shared/large_cta.html.erb" and include the values:</p>
+<p>
+  &lt;%= <strong>render</strong> 'shared/large_cta', <strong>url:</strong> 'http://url.com', <strong>icon:</strong> 'document', <strong>text:</strong> 'Research' %>
+</p>
+<p>The external link icon will automatically be applied when the URL value is external to the fincap domain.</p>
 <h3 class="styleguide__subheading">Document icon</h3>
 <div class="styleguide__example">
-  <a href="www.fincap.org.uk" class="large-cta">
-    <svg xmlns="http://www.w3.org/2000/svg" class="large-cta__icon svg-icon svg-icon--document" focusable="false">
-      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--document"></use>
-    </svg>
-    <span class="large-cta__text">Research</span>
-  </a>
+  <%= render 'shared/large_cta',
+      url: 'http://www.fincap.org.uk',
+      icon: 'document',
+      text: 'Research' %>
 </div>
 <h3 class="styleguide__subheading">Code</h3>
 <xmp>
@@ -19,12 +23,10 @@
 </xmp>
 <h3 class="styleguide__subheading">Money Management icon</h3>
 <div class="styleguide__example">
-  <a href="http://www.fincap.org.uk" class="large-cta">
-    <svg xmlns="http://www.w3.org/2000/svg" class="large-cta__icon svg-icon svg-icon--money" focusable="false">
-      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--money"></use>
-    </svg>
-    <span class="large-cta__text">Money Management</span>
-  </a>
+  <%= render 'shared/large_cta',
+      url: 'http://www.fincap.org.uk',
+      icon: 'money',
+      text: 'Money Management' %>
 </div>
 <h3 class="styleguide__subheading">Code</h3>
 <xmp>
@@ -37,12 +39,10 @@
 </xmp>
 <h3 class="styleguide__subheading">External link</h3>
 <div class="styleguide__example">
-  <a href="http://www.moneyadviceservice.org.uk" class="large-cta">
-    <svg xmlns="http://www.w3.org/2000/svg" class="large-cta__icon svg-icon svg-icon--money" focusable="false">
-      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--money"></use>
-    </svg>
-    <span class="large-cta__text">External link</span>
-  </a>
+  <%= render 'shared/large_cta',
+      url: 'http://www.moneyadviceservice.org.uk',
+      icon: 'money',
+      text: 'External Link' %>
 </div>
 <h3 class="styleguide__subheading">Code</h3>
 <xmp>


### PR DESCRIPTION
# DRYs up the large cta by moving markup into a partial

This PR moves the markup for the large CTA component into a partial to be called with expected values.

A description on how to use this is added to the styleguide, screenshot below:

| Screenshot |
|-------------|
|![image](https://user-images.githubusercontent.com/13165846/37911559-43d68bdc-3108-11e8-8dfa-4382048fc164.png)|
