### PR TITLE
Add feedback component to article pages

### DIFF
--- a/app/models/fincap_article.rb
+++ b/app/models/fincap_article.rb
@@ -1,6 +1,7 @@
 class FincapArticle
   DOWNLOAD_COMPONENT_IDENTIFIER = 'component_download'.freeze
   CTA_LINKS_COMPONENT_IDENTIFIER = 'component_cta_links'.freeze
+  FEEDBACK_COMPONENT_IDENTIFIER = 'component_feedback'.freeze
 
   delegate :title,
            :body,
@@ -19,6 +20,10 @@ class FincapArticle
 
   def download_block
     find_block(DOWNLOAD_COMPONENT_IDENTIFIER)
+  end
+
+  def feedback_block
+    find_block(FEEDBACK_COMPONENT_IDENTIFIER)
   end
 
   private

--- a/app/presenters/article_presenter.rb
+++ b/app/presenters/article_presenter.rb
@@ -11,11 +11,25 @@ class ArticlePresenter < BasePresenter
     view.render('components/cta_links', content: cta_links_content)
   end
 
+  def feedback_component
+    return if feedback_content.blank?
+
+    view.render(
+      'components/feedback',
+      title: view.translate('fincap.components.feedback.title'),
+      email: feedback_content
+    )
+  end
+
   def download_content
     @download_content ||= DownloadComponent.new(download_block).build_markup
   end
 
   def cta_links_content
     @cta_links_content ||= CtaLinksComponent.new(cta_links_block).build_markup
+  end
+
+  def feedback_content
+    feedback_block.try(:content)
   end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -15,8 +15,8 @@
     </div>
     <div class="l-2col-side">
       <%= article.cta_links_component %>
-
       <%= article.download_component %>
+      <%= article.feedback_component %>
     </div>
   </div>
  </div>

--- a/app/views/components/_feedback.html.erb
+++ b/app/views/components/_feedback.html.erb
@@ -1,0 +1,11 @@
+<div class="feedback-box">
+  <h3 class="feedback-box__title">
+    <%= title %>
+  </h3>
+  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
+    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
+  </svg>
+  <a href="mailto:<%= "#{email}" %>" class="feedback-box__text">
+    <%= email.html_safe %>
+  </a>
+</div>

--- a/app/views/shared/_feedback.html.erb
+++ b/app/views/shared/_feedback.html.erb
@@ -1,11 +1,1 @@
-<div class="feedback-box">
-  <h3 class="feedback-box__title">
-    <%= title %>
-  </h3>
-  <svg xmlns="http://www.w3.org/2000/svg" class="feedback-box__icon svg-icon svg-icon--speech" focusable="false">
-    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--speech"></use>
-  </svg>
-  <a href="mailto:<%= "#{email}" %>" class="feedback-box__text">
-    <%= email %>
-  </a>
-</div>
+<%= render 'components/feedback' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,8 @@ en:
     components:
       download:
         title: 'Download'
+      feedback:
+        title: 'Give us your feedback or ask a question'
     life_stages:
       - text: Children and young people
         url: '#'

--- a/features/article_page.feature
+++ b/features/article_page.feature
@@ -27,3 +27,4 @@ Feature: Article page
       | Evaluation Toolkit               | /common-evaluation-toolkit   |
       | The Steering Groups              | /steering-groups             |
       | 2015 Financial Capability Survey | /financial-capability-survey |
+    And I should see the feedback box with the email "email@moneyadviceservice.org.uk"

--- a/features/step_definitions/article_steps.rb
+++ b/features/step_definitions/article_steps.rb
@@ -27,3 +27,7 @@ Then("I should see the call to action box containing the links") do |table|
     expect(row[1]).to be_in(call_to_action_links.map { |link| link[:href] })
   end
 end
+
+Then("I should see the feedback box with the email {string}") do |email|
+  expect(article_page.feedback_box).to have_content(email)
+end

--- a/features/support/ui/pages/article.rb
+++ b/features/support/ui/pages/article.rb
@@ -10,6 +10,8 @@ module UI
 
     class Article < UI::Page
       set_url '/en/articles/{/slug}'
+
+      element :feedback_box, '.feedback-box'
       sections :download_box,
                DownloadBoxSection,
                '.download-box ul.download-box__list li'

--- a/spec/models/fincap_article_spec.rb
+++ b/spec/models/fincap_article_spec.rb
@@ -4,6 +4,40 @@ RSpec.describe FincapArticle do
     double('Mas::Cms::Article', attributes)
   end
 
+  describe '#feedback_block' do
+    context 'when blocks is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'component_feedback',
+              content: 'email@moneyadviceservice.org.uk'
+            )
+          ]
+        }
+      end
+
+      it 'returns feedback component' do
+        expect(subject.feedback_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'component_feedback',
+            content: 'email@moneyadviceservice.org.uk'
+          )
+        )
+      end
+    end
+
+    context 'when blocks is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.feedback_block).to be_nil
+      end
+    end
+  end
+
   describe '.download_block' do
     context 'when blocks is present' do
       let(:attributes) do

--- a/spec/presenters/article_presenter_spec.rb
+++ b/spec/presenters/article_presenter_spec.rb
@@ -58,4 +58,32 @@ RSpec.describe ArticlePresenter do
       end
     end
   end
+
+  describe '#feedback_component' do
+    context 'when article has feedback component' do
+      let(:attributes) do
+        { feedback_block: double(content: 'email@moneyadviceservice.org.uk') }
+      end
+
+      it 'renders download component view' do
+        expect(view).to receive(:render).with(
+          'components/feedback',
+          title: 'Give us your feedback or ask a question',
+          email: 'email@moneyadviceservice.org.uk'
+        )
+        presenter.feedback_component
+      end
+    end
+
+    context 'when article does not have feedback component' do
+      let(:attributes) do
+        { feedback_block: nil }
+      end
+
+      it 'does not render the component' do
+        expect(view).to_not receive(:render)
+        presenter.feedback_component
+      end
+    end
+  end
 end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9162-fincap-article-page-view-or-add)

## Context 

This PR adds the feedback box to article pages.

## List of Article components Pull requests

- [x] Download component https://github.com/moneyadviceservice/fin_cap/pull/94
- [x] CTA links component https://github.com/moneyadviceservice/fin_cap/pull/96
- [x] Feedback component (this PR)
- [ ] Hero image component

## Other part of the work

- [ ] CMS server part of the work (WIP PR) https://github.com/moneyadviceservice/cms/pull/428
- [x] Mas Cms client https://github.com/moneyadviceservice/mas-cms-client/pull/24