### PR TITLE
Adds vertical spacing helper for article page right side components

### DIFF
--- a/app/assets/stylesheets/components/ui/_download_box.scss
+++ b/app/assets/stylesheets/components/ui/_download_box.scss
@@ -1,4 +1,5 @@
 .download-box {
+  @extend %vertical-spacing;
   background-color: $primary-green-pale;
   padding: $baseline-unit*2;
   color: $color-white;

--- a/app/assets/stylesheets/components/ui/_feedback_box.scss
+++ b/app/assets/stylesheets/components/ui/_feedback_box.scss
@@ -1,4 +1,5 @@
 .feedback-box {
+  @extend %vertical-spacing;
   background-color: $primary-blue;
   padding: $baseline-unit*2;
   color: $color-white;

--- a/app/assets/stylesheets/helpers/_all.scss
+++ b/app/assets/stylesheets/helpers/_all.scss
@@ -3,3 +3,4 @@
 @import 'border';
 @import 'visually_hidden';
 @import 'new';
+@import 'vertical_spacing';

--- a/app/assets/stylesheets/helpers/_vertical_spacing.scss
+++ b/app/assets/stylesheets/helpers/_vertical_spacing.scss
@@ -1,0 +1,3 @@
+%vertical-spacing {
+  margin: $baseline-unit 0;
+}


### PR DESCRIPTION
# Adds vertical spacing helper for article page right side components

Currently the article page ui components are bunched together with no space, this PR fixes this by adding a new helper class which applies consistent vertical spacing.

| Screenshot |
|----------|
|<img src="https://user-images.githubusercontent.com/13165846/39305552-6b0eaa62-4955-11e8-8eb2-adf17ba92744.png" width="300" />|
