### PR TITLE
Styleguide: Change nested paragraph tag to span tag

### DIFF
--- a/app/views/shared/_evidence_types.html.erb
+++ b/app/views/shared/_evidence_types.html.erb
@@ -5,6 +5,6 @@
        xlink:href="#svg-icon--evidence-<%= "#{icon}" %>">
   </use>
 </svg>
-<p class="evidence-types__item-content">
+<span class="evidence-types__item-content">
   <%= text %>
-</p>
+</span>

--- a/app/views/styleguide/evidence_types.html.erb
+++ b/app/views/styleguide/evidence_types.html.erb
@@ -24,13 +24,13 @@
       <svg xmlns="http://www.w3.org/2000/svg" class="evidence-types__item-icon evidence-types__item-icon--tick svg-icon svg-icon--evidence-tick" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--evidence-tick"></use>
       </svg>
-      <p class="evidence-types__item-content">Tick icon</p>
+      <span class="evidence-types__item-content">Tick icon</span>
     </li>
     <li class="evidence-types__item">
       <svg xmlns="http://www.w3.org/2000/svg" class="evidence-types__item-icon evidence-types__item-icon--cross svg-icon svg-icon--evidence-cross" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--evidence-cross"></use>
       </svg>
-      <p class="evidence-types__item-content">Cross icon</p>
+      <span class="evidence-types__item-content">Cross icon</span>
     </li>
   </ul>
 </xmp>


### PR DESCRIPTION
The evidence_type icon partial was using a nested paragraph tag which was not rendering correctly if the partial was called within a paragraph tag because HTML5 makes nested p tags illegal. Changing the paragraph tag to a span tag allows the partial to be called within a paragraph tag and correctly renders the icons inline with their corresponding text.

**BEFORE**
<img width="579" alt="screen shot 2018-04-30 at 12 53 55" src="https://user-images.githubusercontent.com/3481059/39476939-9d260168-4d55-11e8-8661-a4d0121e8073.png">

**AFTER**
![screen shot 2018-05-01 at 15 39 28](https://user-images.githubusercontent.com/3481059/39477039-ec926160-4d55-11e8-93d0-4726b26c2e9a.png)

