### PR TITLE
[WIP] 9090 Display bad request message

### DIFF
--- a/app/controllers/evidence_hub_controller.rb
+++ b/app/controllers/evidence_hub_controller.rb
@@ -1,4 +1,6 @@
 class EvidenceHubController < ApplicationController
+  rescue_from Mas::Cms::Errors::ClientError, with: :render_bad_request
+
   DOCUMENT_TYPES = ['Insight'].freeze
 
   def index
@@ -45,5 +47,12 @@ class EvidenceHubController < ApplicationController
 
   def clear_search?
     params[:reset]
+  end
+
+  def render_bad_request(e)
+    Rails.logger.warn(e)
+
+    @error = { status: 400, message: 'Bad request'}
+    render :index
   end
 end

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -30,31 +30,34 @@
         </div>
       </div>
       <div class="l-2col-main">
-        <ul class="search-results">
-          <% present_collection(@evidence_summaries).each do |document| %>
-            <li class="search-results__item">
-              <p class="search-results__title">
-                <%= document.link %>
-              </p>
-              <p class="search-results__description">
-                <%= document.stripped_overview %>
-              </p>
-              <p class="search-results__evidence-type">
-                <%= document.formatted_evidence_type_label %>
-                <%= render 'shared/evaluation_types', type: "#{document.evidence_type}" %>
-              </p>
-              <p class="search-results__topics">
-                <%= document.formatted_topics %>
-              </p>
-              <p class="search-results__countries">
-                <%= document.formatted_countries %>
-              </p>
-              <p class="search-results__year-of-publication">
-                <%= document.formatted_year_of_publication %>
-              </p>
-            </li>
-          <% end %>
-        </ul>
+        <%= render 'shared/error', error: @error if @error %>
+        <% if @evidence_summaries %>
+          <ul class="search-results">
+            <% present_collection(@evidence_summaries).each do |document| %>
+              <li class="search-results__item">
+                <p class="search-results__title">
+                  <%= document.link %>
+                </p>
+                <p class="search-results__description">
+                  <%= document.stripped_overview %>
+                </p>
+                <p class="search-results__evidence-type">
+                  <%= document.formatted_evidence_type_label %>
+                  <%= render 'shared/evaluation_types', type: "#{document.evidence_type}" %>
+                </p>
+                <p class="search-results__topics">
+                  <%= document.formatted_topics %>
+                </p>
+                <p class="search-results__countries">
+                  <%= document.formatted_countries %>
+                </p>
+                <p class="search-results__year-of-publication">
+                  <%= document.formatted_year_of_publication %>
+                </p>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_error.html.erb
+++ b/app/views/shared/_error.html.erb
@@ -1,0 +1,4 @@
+<h2>Error <%= error[:status] %><h2>
+<p><%= error[:message] %></p>
+<p>Your request resulted in an error. Please try again.</p>
+<p><%= link_to 'Go back to evidence summaries', evidence_hub_index_path %></p>


### PR DESCRIPTION
[TP 9090](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiQjRGMUI3NDVDQTgzMEM3QzQ2MDBCNjExRTUxMTQ4OEIifQ==&searchPopup=userstory/9090)

Refer to [cms pr 433](https://github.com/moneyadviceservice/cms/pull/433) and [cms pr 415](https://github.com/moneyadviceservice/cms/pull/415).

This pr gracefully handles the situation where a search has been instigated which includes too many filters. As per cms pr 433, it is low priority and this pr is dependent on cms pr 433 being implemented.