### PR TITLE
9195 data type explanation

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -45,7 +45,8 @@ a {
   }
 
   &[href^="http:"]:not([href*="#{$site}"]):after,
-  &[href^="https:"]:not([href*="#{$site}"]):after {
+  &[href^="https:"]:not([href*="#{$site}"]):after,
+  .evidence-types__item &:after {
     @extend %icon;
     @extend .icon--external-link;
     content: '';

--- a/app/assets/stylesheets/components/ui/_evidence_types.scss
+++ b/app/assets/stylesheets/components/ui/_evidence_types.scss
@@ -7,18 +7,14 @@
 
 .evidence-types__item {
   display: inline-block;
+  margin: 0 $baseline-unit*2 0 0;
 }
 
 .evidence-types__item-icon {
-  display: inline-block;
+  float: left;
   width: 20px;
   height: 20px;
-}
-
-.evidence-types__item-content {
-  display: inline-block;
-  vertical-align: 5px;
-  margin: 0 $baseline-unit 0 0;
+  padding-right: $baseline-unit;
 }
 
 .evidence-types__item-icon--tick {


### PR DESCRIPTION
[TP9195](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=task/9195)

This PR adds to [PR110](https://github.com/moneyadviceservice/fin_cap/pull/110) to add the styles for the icons to be displayed with the quantitative/qualitative descriptions. 

N.B. These are no longer links, they are just descriptions that will become tooltips in a further piece of work ([TP8977](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/8977)).

![image](https://user-images.githubusercontent.com/6080548/39820787-855876e8-539e-11e8-8839-a992c37b4007.png)
