### PR TITLE
Add evidence type and evidence checlist to Insight & Evaluation

### DIFF
--- a/app/controllers/evidence_hub_controller.rb
+++ b/app/controllers/evidence_hub_controller.rb
@@ -1,4 +1,4 @@
-class EvidenceHubController < ApplicationController
+class EvidenceHubController < EvidenceSummariesController
   DOCUMENT_TYPES = %w[Insight Evaluation].freeze
 
   def index

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -60,7 +60,7 @@ class EvidenceSummaryPresenter < BasePresenter
   end
 
   def data_type_keys
-    view.t('fincap.evidence_hub.insight_summary.data_types')
+    view.t("fincap.evidence_hub.#{evidence_type.downcase}_summary.data_types")
   end
 
   def data_type_icon(type)

--- a/app/views/evidence_hub/_search_form.html.erb
+++ b/app/views/evidence_hub/_search_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_for(
+      @search_form,
+      builder: FincapBuilder,
+      url: evidence_hub_index_path,
+      method: :get
+    ) do |f|
+%>
+  <%= f.text_field :keyword %>
+  <%= f.button 'Search', type: 'submit', class: 'btn btn--primary btn--full-width' %>
+  <%= link_to evidence_hub_index_path(reset: true, keyword: @search_form.keyword), class: 'sidepanel__clear-filters' do %>
+    <svg xmlns="http://www.w3.org/2000/svg"
+        class="sidepanel__clear-icon"
+        focusable="false">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--clear-filters"></use>
+    </svg>
+    <span>Clear search</span>
+  <% end %>
+  <div class="sidepanel__divider"></div>
+  <%= render 'filters', f: f, search_form: @search_form %>
+<% end %>

--- a/app/views/evidence_hub/_search_result.html.erb
+++ b/app/views/evidence_hub/_search_result.html.erb
@@ -1,0 +1,23 @@
+<li class="search-results__item">
+  <p class="search-results__title">
+    <%= document.link %>
+  </p>
+  <p class="search-results__description">
+    <%= document.stripped_overview %>
+  </p>
+  <div class="search-results__evidence-type">
+    <%= render 'evidence_type', evidence_summary: document %>
+  </div>
+  <div class="search-results__data-type">
+    <%= render 'evidence_checklist', evidence_summary: document %>
+  </div>
+  <p class="search-results__topics">
+    <%= document.formatted_topics %>
+  </p>
+  <p class="search-results__countries">
+    <%= document.formatted_countries %>
+  </p>
+  <p class="search-results__year-of-publication">
+    <%= document.formatted_year_of_publication %>
+  </p>
+</li>

--- a/app/views/evidence_hub/index.html.erb
+++ b/app/views/evidence_hub/index.html.erb
@@ -12,56 +12,14 @@
       <div class="l-2col-side">
         <div class="sidepanel">
           <h4 class="sidepanel__title">Keyword search</h4>
-          <%= form_for(
-            @search_form, builder: FincapBuilder, url: evidence_hub_index_path, method: :get) do |f| %>
-            <%= f.text_field :keyword %>
-            <%= f.button 'Search', type: 'submit', class: 'btn btn--primary btn--full-width' %>
-            <%= link_to evidence_hub_index_path(reset: true, keyword: @search_form.keyword), class: 'sidepanel__clear-filters' do %>
-              <svg xmlns="http://www.w3.org/2000/svg" 
-                  class="sidepanel__clear-icon" 
-                  focusable="false">
-                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--clear-filters"></use>
-              </svg>
-              <span>Clear search</span>
-            <% end %>
-            <div class="sidepanel__divider"></div>
-            <%= render 'filters', f: f, search_form: @search_form %>
-          <% end %>
+
+          <%= render 'search_form' %>
         </div>
       </div>
       <div class="l-2col-main">
         <ul class="search-results">
           <% present_collection(@evidence_summaries).each do |document| %>
-            <li class="search-results__item">
-              <p class="search-results__title">
-                <%= document.link %>
-              </p>
-              <p class="search-results__description">
-                <%= document.stripped_overview %>
-              </p>
-              <div class="search-results__evidence-type">
-                <%= document.formatted_evidence_type_label %>
-                <%= render 'shared/evaluation_types', type: "#{document.evidence_type}" %>
-              </div>
-              <div class="search-results__data-type">
-                <ul class="evidence-types">
-                  <% document.data_type_keys.each do |data_type| %>
-                    <li class="evidence-types__item data-types__<%= "#{data_type.downcase}" %>">
-                      <%= render 'shared/evidence_types', icon: document.data_type_icon(data_type), text: data_type %>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-              <p class="search-results__topics">
-                <%= document.formatted_topics %>
-              </p>
-              <p class="search-results__countries">
-                <%= document.formatted_countries %>
-              </p>
-              <p class="search-results__year-of-publication">
-                <%= document.formatted_year_of_publication %>
-              </p>
-            </li>
+            <%= render 'search_result', document: document %>
           <% end %>
         </ul>
       </div>

--- a/app/views/evidence_summaries/_content.html.erb
+++ b/app/views/evidence_summaries/_content.html.erb
@@ -1,6 +1,11 @@
 <h1 class="evidence-hub__title">
   <%= evidence_summary.title %>
 </h1>
+<div class="evidence_hub__evidence_type">
+  <%= render 'evidence_type', evidence_summary: evidence_summary %>
+</div>
+<%= render 'evidence_checklist', evidence_summary: evidence_summary %>
 <div class="evidence-hub__content">
   <%= evidence_summary.content.html_safe %>
 </div>
+

--- a/app/views/evidence_summaries/_evidence_checklist.html.erb
+++ b/app/views/evidence_summaries/_evidence_checklist.html.erb
@@ -1,0 +1,9 @@
+<ul class="evidence-types">
+  <% evidence_summary.data_type_keys.each do |data_type| %>
+    <li class="evidence-types__item data-types__<%= "#{data_type.parameterize}" %>">
+      <%= render 'shared/evidence_types',
+                 icon: evidence_summary.data_type_icon(data_type),
+                 text: data_type %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/evidence_summaries/_evidence_type.html.erb
+++ b/app/views/evidence_summaries/_evidence_type.html.erb
@@ -1,0 +1,2 @@
+<%= evidence_summary.formatted_evidence_type_label %>
+<%= render 'shared/evaluation_types', type: "#{evidence_summary.evidence_type}" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,13 @@ en:
         data_types:
           - Qualitative
           - Quantitative
+      evaluation_summary:
+        data_types:
+          - Programme Theory
+          - Measured Outcomes
+          - Causality
+          - Process Evaluation
+          - Value for money
       key_info: 'Key info'
       insight_summary_name: 'Insight'
       evaluation_summary_name: 'Evaluation'

--- a/features/evaluation_summary_page.feature
+++ b/features/evaluation_summary_page.feature
@@ -19,3 +19,10 @@ Feature: Evidence Hub: Evaluation Summary page
       | Country                | United Kingdom                                        |
       | Contact information    | MASPD (in partnership with Company S.A)               |
       | Links                  | Looking after the pennies - full report               |
+    And I should see the evidence summary data_types
+      | Field                       | Value |
+      | programme_theory            | cross |
+      | measured_outcomes_checklist | tick  |
+      | causality                   | cross |
+      | process_evaluation          | cross |
+      | value_for_money             | cross |

--- a/features/insight_summary_page.feature
+++ b/features/insight_summary_page.feature
@@ -16,3 +16,7 @@ Feature: Evidence Hub: Insight Summary page
       | Country             | United Kingdom                                           |
       | Contact information | MASPD (in partnership with Company S.A)                  |
       | Links               | Financial well-being: the employee view - full report    |
+    And I should see the evidence summary data_types
+      | Field        | Content |
+      | qualitative  | tick    |
+      | quantitative | cross   |

--- a/features/step_definitions/evidence_hub/show_steps.rb
+++ b/features/step_definitions/evidence_hub/show_steps.rb
@@ -13,3 +13,13 @@ Then('I should see the evidence summary content') do |table|
     expect(content).to include(row[1])
   end
 end
+
+Then('I should see the evidence summary data_types') do |table|
+  table.rows.each do |row|
+    data_type_element = evidence_summary_page.send(row[0])
+    data_type_element_class = data_type_element['class']
+    icon_class_value = data_type_element_class[/tick|cross/]
+
+    expect(icon_class_value).to eq(row[1])
+  end
+end

--- a/features/support/ui/pages/evidence_summaries.rb
+++ b/features/support/ui/pages/evidence_summaries.rb
@@ -11,6 +11,11 @@ module UI::Pages
       element :year_of_publication, '.search-results__year-of-publication'
       element :qualitative, '.data-types__qualitative svg'
       element :quantitative, '.data-types__quantitative svg'
+      element :programme_theory, '.data-types__programme-theory svg'
+      element :measured_outcomes, '.data-types__measured-outcomes svg'
+      element :causality, '.data-types__causality svg'
+      element :process_evaluation, '.data-types__process-evaluation svg'
+      element :value_for_money, '.data-types__value-for-money svg'
     end
 
     set_url '{/locale}/evidence_hub'

--- a/features/support/ui/pages/evidence_summary.rb
+++ b/features/support/ui/pages/evidence_summary.rb
@@ -14,6 +14,13 @@ module UI
       element :country, '.evidence-hub__country'
       element :contact_information, '.evidence-hub__contact_information'
       element :links, '.evidence-hub__links'
+      element :qualitative, '.data-types__qualitative svg'
+      element :quantitative, '.data-types__quantitative svg'
+      element :programme_theory, '.data-types__programme-theory svg'
+      element :measured_outcomes_checklist, '.data-types__measured-outcomes svg'
+      element :causality, '.data-types__causality svg'
+      element :process_evaluation, '.data-types__process-evaluation svg'
+      element :value_for_money, '.data-types__value-for-money svg'
     end
   end
 end

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -232,10 +232,34 @@ RSpec.describe EvidenceSummaryPresenter do
   end
 
   describe '#data_type_keys' do
-    it 'returns an array of the different data_types' do
-      expect(presenter.data_type_keys).to match_array(
-        %w[Qualitative Quantitative]
-      )
+    context 'when evidence type is insight' do
+      let(:attributes) do
+        { evidence_type: 'Insight' }
+      end
+
+      it 'returns an array of the different data_types' do
+        expect(presenter.data_type_keys).to match_array(
+          %w[Qualitative Quantitative]
+        )
+      end
+    end
+
+    context 'when evidence type evaluation' do
+      let(:attributes) do
+        { evidence_type: 'Evaluation' }
+      end
+
+      it 'returns an array of the different data_types' do
+        expect(presenter.data_type_keys).to match_array(
+          [
+            'Programme Theory',
+            'Measured Outcomes',
+            'Causality',
+            'Process Evaluation',
+            'Value for money'
+          ]
+        )
+      end
     end
   end
 


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9189-add-evaluation-checklist-to-the-evaluation) and [TP card](https://moneyadviceservice.tpondemand.com/entity/9167-display-qualitative-and-quantitative-data-types)

## Context

This PR adds the insight checklist and evaluation checklist to the respective individual pages.

## Solution

So now the evidence hub controller inherits from evidence summaries controller
altogether with Insight and Evaluation.

**Which means any evidence summary page will have by default the checklist from the config/locales/en.yml.**

Also refactor the evidence hub index view to have a search form partial as
well as search result. I was not sure if I should be adding on the same PR but I kinda need to re-use the checklist for different page types so I decide to include on the PR.

## Conclusion

So now to add a evidence checklist for new evidence hub page types:

1) add the values on the config/locale/en.yml on `"#{page_type}_summary.data_types"`
2) add the already existing steps of cucumber to the feature test
3) add the method on the site prism test page objects.
