### PR TITLE
Fix broken presenter tests and feature specs

### DIFF
--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -59,7 +59,7 @@ class EvidenceSummaryPresenter < BasePresenter
     "#{year_of_publication_field_name}: #{stripped_year_of_publication}"
   end
 
-  def data_type_keys
+  def data_type_definitions
     view.t("fincap.evidence_hub.#{evidence_type.downcase}_summary.data_types")
   end
 

--- a/app/views/evidence_summaries/_evidence_checklist.html.erb
+++ b/app/views/evidence_summaries/_evidence_checklist.html.erb
@@ -1,6 +1,6 @@
 <ul class="evidence-types">
-  <% evidence_summary.data_type_keys.each do |data_type| %>
-    <li class="evidence-types__item data-types__<%= data_type[:keyword].downcase %>">
+  <% evidence_summary.data_type_definitions.each do |data_type| %>
+    <li class="evidence-types__item data-types__<%= data_type[:keyword].parameterize %>">
       <div class="tooltip" data-dough-component="Tooltip" role="tooltip">
         <button class="tooltip__trigger" aria-describedby="<%= data_type[:keyword] %>">
           <%= render 'shared/evidence_types',

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -231,15 +231,22 @@ RSpec.describe EvidenceSummaryPresenter do
     end
   end
 
-  describe '#data_type_keys' do
+  describe '#data_type_definitions' do
     context 'when evidence type is insight' do
       let(:attributes) do
         { evidence_type: 'Insight' }
       end
 
-      it 'returns an array of the different data_types' do
-        expect(presenter.data_type_keys).to match_array(
-          %w[Qualitative Quantitative]
+      it 'returns array of hashes for the different data_types' do
+        # rubocop:disable Metrics/LineLength
+        qualitative_def = 'Qualitative research is more exploratory, and uses a range of methods like interviews, focus groups and observation to gain a deeper understanding about specific issues - such as people’s experiences, behaviours and attitudes.'
+        quantitative_def = 'Quantitative research uses statistical or numerical analysis of survey data to answer questions about how much, how many, how often or to what extent particular characteristics are seen in a population. It is often used to look at changes over time and can identify relationships between characteristics like people’s attitudes and behaviours.'
+        # rubocop:enable Metrics/LineLength
+        expect(presenter.data_type_definitions).to match_array(
+          [
+            { keyword: 'Qualitative', definition: qualitative_def },
+            { keyword: 'Quantitative', definition: quantitative_def }
+          ]
         )
       end
     end
@@ -249,14 +256,16 @@ RSpec.describe EvidenceSummaryPresenter do
         { evidence_type: 'Evaluation' }
       end
 
-      it 'returns an array of the different data_types' do
-        expect(presenter.data_type_keys).to match_array(
+      it 'returns array of hashes for the different data_types' do
+        expect(presenter.data_type_definitions).to match_array(
           [
-            'Programme Theory',
-            'Measured Outcomes',
-            'Causality',
-            'Process Evaluation',
-            'Value for money'
+            # rubocop:disable Metrics/LineLength
+            { keyword: 'Programme Theory', definition: 'Information about the programme design and rationale' },
+            { keyword: 'Measured Outcomes', definition: 'Evidence about Financial Capability outcomes for programme participants' },
+            { keyword: 'Causality', definition: 'Evidence that the Financial Capability outcomes were caused by the programme' },
+            { keyword: 'Process Evaluation', definition: 'Evidence about programme implementation, feasibility, and piloting' },
+            { keyword: 'Value for money', definition: 'Evidence about relative costs and benefits of the programme' }
+            # rubocop:enable Metrics/LineLength
           ]
         )
       end


### PR DESCRIPTION
Presenter tests were broken because the translations file had changed in structure. This pr amends the presenter tests to reflect the new structure.

Feature tests were breaking because the class for the particular data type was not hyphenated and therefore the css being looked for did not exist, i.e. `programme theory` instead of `programme-theory`.

I also changed the presenter method name to better reflect its changed responsibility.