### PR TITLE
[DEV APPROVED] 9233 Styleguide CTA List Bug

### DIFF
--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -44,6 +44,13 @@
 
   li {
     margin-top: $baseline-unit;
+    padding: $baseline-unit;
+    border: 2px solid $primary-orange;
+    border-radius: $border-radius;
+
+    &:hover {
+      border-color: $primary-blue-dark;
+    }
 
     &::before {
       display: none;
@@ -52,22 +59,16 @@
 
   a {
     display: block;
-    padding: $baseline-unit;
+    padding: 0 23px; // 18px for the arrow (_icons.scss) and a little extra for spacing
     color: $color-black;
     text-align: center;
-    border: 2px solid $primary-orange;
-    border-radius: $border-radius;
     position: relative;
-
-    &:hover {
-      border-color: $primary-blue-dark;
-    }
 
     &:after {
       content: '';
       position: absolute;
-      right: $baseline-unit;
-      top: $baseline-unit;
+      right: 0;
+      top: 0;
       @extend %icon;
       @extend .icon--arrow;
     }


### PR DESCRIPTION
# 9233 Styleguide CTA List Bug
[TP9233](https://moneyadviceservice.tpondemand.com/entity/9233-bug-grouped-cta-list-text-overlap)

This PR moves the padding and border styles on the styleguide's list CTA to be on the li not the a, so that padding can be added to the sides of the a, which stops the text overlapping the arrow icon.

===

Before:
![image](https://user-images.githubusercontent.com/3898629/40707624-29420be8-63e9-11e8-9171-afe282ea80ea.png)

After:
<img width="328" alt="screen shot 2018-05-30 at 09 06 28" src="https://user-images.githubusercontent.com/3898629/40707509-c71f1294-63e8-11e8-8a3b-87bc9b5bd34d.png">
<img width="344" alt="screen shot 2018-05-30 at 09 08 17" src="https://user-images.githubusercontent.com/3898629/40707594-07a6fd86-63e9-11e8-8abb-4648b16e9ec5.png">
