### PR TITLE
[DEV APPROVED] 9229 Evidence Type spacing bug

### DIFF
--- a/app/assets/stylesheets/components/ui/_search_results.scss
+++ b/app/assets/stylesheets/components/ui/_search_results.scss
@@ -21,3 +21,7 @@
   margin-top: $baseline-unit;
   text-decoration: underline;
 }
+
+.search-results__evidence-type {
+  margin: 1em 0;
+}


### PR DESCRIPTION
# 9229 Evidence Type spacing bug
[TP9229](https://moneyadviceservice.tpondemand.com/entity/9229-bug-consistent-spacing-between-evidence-type)

This PR adds margin to the search result's evidence type

===

Before:
<img width="330" alt="screen shot 2018-05-30 at 09 50 58" src="https://user-images.githubusercontent.com/3898629/40709843-01040022-63ef-11e8-95b0-6c931d475a75.png">

After:
<img width="370" alt="screen shot 2018-05-30 at 09 51 05" src="https://user-images.githubusercontent.com/3898629/40709846-05e033c2-63ef-11e8-8a3c-71072b0410de.png">
