### PR TITLE
[DEV APPROVED] TP: 9234, Comment: Limits pagination display

### DIFF
--- a/app/presenters/evidence_summaries_presenter.rb
+++ b/app/presenters/evidence_summaries_presenter.rb
@@ -17,6 +17,8 @@ class EvidenceSummariesPresenter < BasePresenter
   end
 
   def pagination_description
+    return nil unless show_pagination?
+
     view.t(
       'fincap.evidence_hub.pagination.pagination_description',
       current_page: current_page,
@@ -25,6 +27,8 @@ class EvidenceSummariesPresenter < BasePresenter
   end
 
   def previous_page
+    return nil unless show_pagination?
+
     if first_page?
       PAGINATION_PREVIOUS_TEXT
     else
@@ -39,6 +43,8 @@ class EvidenceSummariesPresenter < BasePresenter
   end
 
   def next_page
+    return nil unless show_pagination?
+
     if last_page?
       PAGINATION_NEXT_TEXT
     else
@@ -76,5 +82,9 @@ class EvidenceSummariesPresenter < BasePresenter
 
   def next_page_number
     current_page + 1
+  end
+
+  def show_pagination?
+    total_pages.to_i > 1
   end
 end

--- a/spec/presenters/evidence_summaries_presenter_spec.rb
+++ b/spec/presenters/evidence_summaries_presenter_spec.rb
@@ -89,4 +89,100 @@ RSpec.describe EvidenceSummariesPresenter do
       end
     end
   end
+
+  describe '#pagination_description' do
+    context 'when no results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 0 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.pagination_description).to be_nil
+      end
+    end
+
+    context 'when one results page' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 1 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.pagination_description).to be_nil
+      end
+    end
+
+    context 'when two results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 2, 'page' => 1 } }
+      end
+
+      it 'returns pagination' do
+        expect(presenter.pagination_description).to eq('1 of 2')
+      end
+    end
+  end
+
+  describe '#previous_page' do
+    context 'when no results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 0 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.previous_page).to be_nil
+      end
+    end
+
+    context 'when one results page' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 1 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.previous_page).to be_nil
+      end
+    end
+
+    context 'when two results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 2, 'page' => 1 } }
+      end
+
+      it 'returns previous_page' do
+        expect(presenter.previous_page).to eq('<')
+      end
+    end
+  end
+
+  describe '#next_page' do
+    context 'when no results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 0 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.next_page).to be_nil
+      end
+    end
+
+    context 'when one results page' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 1 } }
+      end
+
+      it 'returns nil' do
+        expect(presenter.next_page).to be_nil
+      end
+    end
+
+    context 'when two results pages' do
+      let(:attributes) do
+        { meta: { 'total_pages' => 2, 'page' => 2 } }
+      end
+
+      it 'returns next_page' do
+        expect(presenter.next_page).to eq('>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
[TP9234](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&searchPopup=bug/9234)

Currently, the pagination is always displayed regardless of the number of results returned from a search. 

![image](https://user-images.githubusercontent.com/6080548/40770941-f10d59e6-64b3-11e8-86c6-f7eea9aeca05.png)

This PR only displays the pagination when there are more than one page of results. 

![image](https://user-images.githubusercontent.com/6080548/40770952-f747562c-64b3-11e8-976c-18eddf8fc861.png)
