### PR TITLE
[DEV APPROVED] 9228 evidence i icon visited color bug

### DIFF
--- a/app/assets/stylesheets/components/_icons.scss
+++ b/app/assets/stylesheets/components/_icons.scss
@@ -48,7 +48,11 @@
   vertical-align: middle;
   margin-left: $baseline-unit;
   font-weight: 500;
-
+  
+  &:visited {
+    color: $color-white;
+  }
+  
   &:hover {
     background: lighten($primary-blue-dark, 30%);
     text-decoration: none;


### PR DESCRIPTION
# 9228 Evidence i bug
[TP9228](https://moneyadviceservice.tpondemand.com/entity/9228-bug-evidence-type-i-icon-colour)

This PR adds in extra styling so that the I is still white after visiting link


Screenshots
===
Before:
<img width="268" alt="screen shot 2018-06-04 at 13 46 36" src="https://user-images.githubusercontent.com/3898629/40918276-bcb5f886-67fd-11e8-95eb-afc650379919.png">
After:
<img width="258" alt="screen shot 2018-06-04 at 13 46 12" src="https://user-images.githubusercontent.com/3898629/40918283-c0a5149a-67fd-11e8-9707-8530638e3037.png">
