### PR TITLE
9236 Missing viewport meta tag bug

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,8 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
       <%= render 'shared/svg/icon_sprite' %>
     <!--<![endif]-->

--- a/app/views/layouts/styleguide.html.erb
+++ b/app/views/layouts/styleguide.html.erb
@@ -7,6 +7,8 @@
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
       <%= render 'shared/svg/icon_sprite' %>
     <!--<![endif]-->


### PR DESCRIPTION
# 9236 Missing viewport meta tag
[TP9236](https://moneyadviceservice.tpondemand.com/entity/9236-bug-viewport-meta-tag-missing)

This PR adds in the viewport meta tag so that the site scales correctly on mobile.

Screenshots
===
Before:
<img width="367" alt="screen shot 2018-06-05 at 07 29 03" src="https://user-images.githubusercontent.com/3898629/40958704-2c934db8-6892-11e8-861f-137591dad74c.png">

After:
<img width="358" alt="screen shot 2018-06-05 at 07 27 55" src="https://user-images.githubusercontent.com/3898629/40958719-366f0f2a-6892-11e8-9653-7bfe508d3b18.png">
