### PR TITLE
[DEV APPROVED] updated brakeman to stop failing jenkins tests on prs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     bindex (0.5.0)
     bowndler (1.0.2)
       thor
-    brakeman (4.3.0)
+    brakeman (4.3.1)
     builder (3.2.3)
     capybara (2.18.0)
       addressable


### PR DESCRIPTION
This PR updates brakeman from 4.3.0 to 4.3.1 as jenkins tests were failing on PRs with the message

`=== Running brakeman -q --no-pager --ensure-latest`
`Brakeman 4.3.0 is not the latest version 4.3.1`
`=== These tests failed.`