### PR TITLE
[WIP] 9295 research and evaluation partial

### DIFF
--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -17,6 +17,7 @@
 
   li {
     position: relative;
+    padding-right: 20px;
 
     &::before {
       display: none;

--- a/app/assets/stylesheets/layout/common/_2_col.scss
+++ b/app/assets/stylesheets/layout/common/_2_col.scss
@@ -1,11 +1,17 @@
 // Layout 2 columns
 //
 // Styleguide layout-2col
+.l-2col {
+  @extend %clearfix;
+}
 
 .l-2col-side {
 @include column(12);
   @include respond-to($mq-m) {
     @include column(4);
+    .l-2col-no-margin & {
+      @include column-to-edge(4, 2);
+    }
   }
 }
 
@@ -13,6 +19,9 @@
   @include column(12);
     @include respond-to($mq-m) {
     @include column(8);
+    .l-2col-no-margin & {
+      @include column-to-edge(8, 2);
+    }
   }
 }
 
@@ -21,6 +30,9 @@
 
   @include respond-to($mq-m) {
     @include column(6);
+    .l-2col-no-margin & {
+      @include column-to-edge(6, 2);
+    }
   }
 }
 
@@ -36,4 +48,15 @@
 .l-2col-even-right--unresponsive {
   @extend .l-2col-even--unresponsive;
   float: right;
+}
+
+.l-2col-flex {
+  @include respond-to($mq-m) {
+    display: flex;
+    .l-2col-side,
+    .l-2col-main,
+    .l-2col-even {
+      flex: 1;
+    }
+  }
 }

--- a/app/assets/stylesheets/layout/common/_3_col.scss
+++ b/app/assets/stylesheets/layout/common/_3_col.scss
@@ -1,11 +1,26 @@
 // Layout 3 columns
 //
 // Styleguide layout-3col
+.l-3col {
+  @extend %clearfix;
+}
 
 .l-3col-even {
   @include column(12);
 
   @include respond-to($mq-m) {
     @include column(4);
+    .l-2col-no-margin & {
+      @include column-to-edge(4, 3);
+    }
+  }
+}
+
+.l-3col-flex {
+  @include respond-to($mq-m) {
+    display: flex;
+    .l-3col-even {
+      flex: 1;
+    }
   }
 }

--- a/app/assets/stylesheets/lib/_grid.scss
+++ b/app/assets/stylesheets/lib/_grid.scss
@@ -32,6 +32,25 @@ $total-width: 100%;
   margin-right: $total-width*(($gutter-width*.5)/gridsystem-width($columns));
 }
 
+@mixin column-to-edge($x, $total, $columns: $columns) {
+  // @if ($x != 12) {
+    display: inline;
+    float: left;
+    width: $total-width*(((($gutter-width+$column-width)*$x)-$gutter-width*0.5) / gridsystem-width($columns));
+    margin-left: $total-width*(($gutter-width*.5)/gridsystem-width($columns));
+    margin-right: $total-width*(($gutter-width*.5)/gridsystem-width($columns));
+    &:nth-child(#{$total}n - 1) {
+      margin-left: 0;
+    }
+    &:nth-child(#{$total}n) {
+      margin-right: 0;
+    }
+  // } 
+  // @else {
+  //   @include column(12);
+  // }
+}
+
 @mixin push($offset: 1) {
   margin-left: $total-width*((($gutter-width+$column-width)*$offset) / gridsystem-width($columns)) + $total-width*(($gutter-width*.5)/gridsystem-width($columns));
 }

--- a/app/views/lifestages/show.html.erb
+++ b/app/views/lifestages/show.html.erb
@@ -39,7 +39,10 @@
     <div class="l-constrained">
       <div class="l-2col">
         <div class="l-2col-main">      
-          <%= render "shared/research" %>   
+          <div class="row">
+              <%= render 'shared/research_and_evaluation' %>
+          </div>  
+
           <div class="row">
             <%= render "lifestages/strategy_box",
               title: template.strategy_title_component,

--- a/app/views/shared/_research_and_evaluation.html.erb
+++ b/app/views/shared/_research_and_evaluation.html.erb
@@ -1,0 +1,26 @@
+<div class="l-2col l-2col-no-margin l-2col-flex">
+  <div class="l-2col-even coloured-box">
+    <h2 class="coloured-box__title">Research and findings</h2>
+    <ul class="list list--links coloured-box__list">
+      <% I18n.t('fincap.research_evaluation.findings').each do |link| %>
+        <li>
+          <a href="<%= link[:url] %>">
+            <%= link[:text] %>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="l-2col-even coloured-box">
+    <h2 class="coloured-box__title">Evaluate your programme</h2>
+    <ul class="list list--links coloured-box__list">
+      <% I18n.t('fincap.research_evaluation.existing').each do |link| %>
+        <li>
+          <a href="<%= link[:url] %>">
+            <%= link[:text] %>
+          </a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/styleguide/layout.html.erb
+++ b/app/views/styleguide/layout.html.erb
@@ -1,6 +1,30 @@
 <h1>Layout</h1>
+<h2>List variants</h2>
+<ul class="styleguide__list">
+  <li class="styleguide__list-item">
+    <a href="#default">Layout container</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-1">1 Column Layout</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-2-l">2 columns small on left</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-2-r">2 columns small on right</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-2">2 columns even</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-3">3 columns even</a>
+  </li>
+  <li class="styleguide__list-item">
+    <a href="#col-h-m">Equal hights column & no edge margin</a>
+  </li>
+</ul>
 
-<h3 class="styleguide__subheading">Layout container</h3>
+<h3 class="styleguide__subheading" id="default">Layout container</h3>
 <div class="l-constrained">
   <div class="styleguide__example">
     <h3>1 column, full width of container</h3>
@@ -14,7 +38,7 @@
   </div>
 </xmp>
 
-<h3 class="styleguide__subheading">1 Column Layout</h3>
+<h3 class="styleguide__subheading" id="col-1">1 Column Layout</h3>
 <div class="l-constrained">
   <div class="l-1col">
     <div class="styleguide__example">
@@ -32,7 +56,7 @@
   </div>
 </xmp>
 
-<h3 class="styleguide__subheading">2 columns small on left</h3>
+<h3 class="styleguide__subheading" id="col-2-l">2 columns small on left</h3>
 <div class="l-constrained">
   <div class="styleguide__example">
     <div class="l-2col">
@@ -60,7 +84,7 @@
   </div>
 </xmp>
 
-<h3 class="styleguide__subheading">2 columns small on right</h3>
+<h3 class="styleguide__subheading" id="col-2-r">2 columns small on right</h3>
 <div class="l-constrained">
   <div class="styleguide__example">
     <div class="l-2col-main">
@@ -86,7 +110,7 @@
   </div>
 </xmp>
 
-<h3 class="styleguide__subheading">2 columns even</h3>
+<h3 class="styleguide__subheading" id="col-2">2 columns even</h3>
 <div class="l-constrained">
   <div class="styleguide__example">
     <div class="l-2col-even">
@@ -112,7 +136,7 @@
   </div>
 </xmp>
 
-<h3 class="styleguide__subheading">3 columns even</h3>
+<h3 class="styleguide__subheading" id="col-3">3 columns even</h3>
 <div class="l-constrained">
   <div class="styleguide__example">
     <% 3.times do %>
@@ -131,5 +155,33 @@
         <h3>1/3</h3>
       </div>
     <% end %>
+  </div>
+</xmp>
+
+<h3 class="styleguide__subheading" id="col-h-m">Equal hights column & no edge margin</h3>
+<div class="l-constrained">
+  <div class="styleguide__example l-2col-flex l-2col-no-margin">
+    <div class="l-2col-even coloured-box">
+      <h3>Short content</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </p>
+    </div>
+    <div class="l-2col-even coloured-box">
+      <h3>Long content</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
+  </div>
+</div>
+
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <div class="l-constrained l-2col-flex l-2col-no-margin">
+    <div class="l-2col-even coloured-box">
+      <h3>Short content</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </p>
+    </div>
+    <div class="l-2col-even coloured-box">
+      <h3>Long content</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    </div>
   </div>
 </xmp>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,19 @@ en:
         url: '#'
       - text: People trying to save
         url: '#'
+    research_evaluation:
+      findings:
+        - text: Existing Research
+          url: 'link-to/financial-capability-survey'
+        - text: Evidence hub
+          url: 'link-to/evidence_hub'
+      existing:
+        - text: Measure your performance
+          url: 'link-to/evaluate-your-programme'
+        - text: Evaluation toolkit
+          url: 'link-to/evaluation-toolkit-homepage'
+        - text: Outcomes Frameworks and question banks
+          url: 'link-to/outcome-framework'
     countries:
       title: The Strategy across the UK
       intro: As well as the UK Strategy, there are strategies for Northern Ireland, Scotland and Wales.


### PR DESCRIPTION
[TP9295](https://moneyadviceservice.tpondemand.com/entity/9295-research-and-evaluation-solid-colour-box)

This PR 
1. tweaks the layout component in the styleguide to allow for equal heights (flex) columns and no margin on the columns on the edges (1&2 if there's 3 columns, 1&4 if there's 4 columns, etc.) so that the row fills available space. 
2. adds in the research and evaluation partial which uses this styling and is present on multiple pages, so far only the lifestyle page. 