### PR TITLE
[DEV APPROVED] 9305 latest news frontend

### DIFF
--- a/app/assets/stylesheets/components/ui/_latest_news.scss
+++ b/app/assets/stylesheets/components/ui/_latest_news.scss
@@ -1,34 +1,53 @@
 .latest-news {
-  @include column(12);
   position: relative;
 }
+.latest-news:not(.latest-news__snippet) {
+  @extend .latest-news;
+  @extend .bordered-box;
+}
 
-.latest-news__icon {
+.latest-news:not(.latest-news__snippet) .latest-news__icon {
   position: absolute;
   top: $baseline-unit*3;
   right: $baseline-unit*3;
 }
 
-.latest-news__inner {
-  border: 2px solid $grey-lighter;
+.latest-news:not(.latest-news__snippet) .latest-news__inner {
+  @extend .bordered-box__inner;
   padding: $baseline-unit*2;
 }
 
 .latest-news__title {
   color: $primary-orange;
-  margin: 0 0 $baseline-unit*2;
+  margin: 0 0 $baseline-unit*3;
   padding: 0 $baseline-unit*6 0 0;
 }
 
 .latest-news__list {
-  margin: $baseline-unit*3 0 $baseline-unit;
+  margin: 0 0 $baseline-unit;
   padding: 0;
   list-style: none;
 }
 
 .latest-news__list-item {
+  @include clearfix;
   @include body(14, 24);
   margin: $baseline-unit*2 0;
+}
+
+.latest-news__item-icon,
+.latest-news__content {
+  float: left;
+  display: inline-block;
+}
+
+.latest-news__item-icon {
+  width: 40px;
+}
+
+.latest-news__content {
+  margin-left: $baseline-unit * 2;
+  width: calc(100% - 40px - #{$baseline-unit * 2});
 }
 
 .latest-news__list-item__date {
@@ -40,8 +59,6 @@
 }
 
 .latest-news__list-item__cta {
-  position: relative;
-  display: block;
   margin-top: $baseline-unit;
   font-weight: 500;
 
@@ -49,6 +66,14 @@
     @extend %icon;
     @extend .icon--arrow;
     content: '';
+    margin-left: $baseline-unit;
+  }
+}
+.latest-news:not(.latest-news__snippet) .latest-news__list-item__cta {
+  position: relative;
+  display: block;
+
+  &:after {
     position: absolute;
     right: 0;
     top: 0;

--- a/app/presenters/latest_news_template_presenter.rb
+++ b/app/presenters/latest_news_template_presenter.rb
@@ -1,2 +1,7 @@
 class LatestNewsTemplatePresenter < TemplatePresenter
+  HERO_COLOUR = 'orange'.freeze
+
+  def hero_colour_css_class
+    "hero--#{HERO_COLOUR}"
+  end
 end

--- a/app/views/components/_hero.html.erb
+++ b/app/views/components/_hero.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="hero" style="background-image: url(<%= img_src %>);">
+  <div class="hero <%= css_class %>" style="background-image: url(<%= img_src %>);">
     <h1 class="hero__heading"><%= description.html_safe %></h1>
   </div>
 </div>

--- a/app/views/components/_hero.html.erb
+++ b/app/views/components/_hero.html.erb
@@ -1,5 +1,6 @@
+<% hero_colour = '' if local_assigns[:hero_colour].nil? %>
 <div class="row">
-  <div class="hero <%= css_class %>" style="background-image: url(<%= img_src %>);">
+  <div class="hero <%= hero_colour %>" style="background-image: url(<%= img_src %>);">
     <h1 class="hero__heading"><%= description.html_safe %></h1>
   </div>
 </div>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -3,7 +3,7 @@
     <%= render '/components/hero', 
       img_src: template.hero_image_component, 
       description: template.title,
-      css_class: "hero--orange" 
+      hero_colour: template.hero_colour_css_class
     %>
     <div class='row'>
       <div class="l-constrained">

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -2,23 +2,37 @@
   <% present(@index_page) do |template| %>
     <%= render '/components/hero', 
       img_src: template.hero_image_component, 
-      description: template.title 
+      description: template.title,
+      css_class: "hero--orange" 
     %>
     <div class='row'>
       <div class="l-constrained">
         <div class="l-2col">
           <div class="l-2col-main">
             <div class="body-content"><%= template.body.html_safe %></div>
-            <div class='row'>
-              <ul>
+            <div class="latest-news__snippet l-constrained">
+              <ul class="latest-news__list">
                 <% present_collection(resource_collection).each do |template| %>
-                  <li>
-                    <%= template.order_by_date_component %>
-                    <%= link_to template.title, template.full_path %>
+                  <li class="latest-news__list-item">
+                    <div class="latest-news__item-icon">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="latest-news__icon svg-icon svg-icon--latest-news" focusable="false">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--latest-news"></use>
+                      </svg>
+                    </div>
+                    <div class="latest-news__content">
+                      <p class="latest-news__list-item__date">
+                        <%= template.order_by_date_component %>
+                      </p>
+                      <p class="latest-news__list-item__text">
+                        <%= template.title %>
+                      </p>
+                      <a href="<%= template.full_path %>" class="latest-news__list-item__cta"><%= I18n.t('fincap.news.more_individual') %></a>
+                    </div>
                   </li>
                 <% end %>
-              </div>
-            </ul>
+              </ul>
+              <a href="#" class="btn btn--primary btn--orange"><%= I18n.t('fincap.news.more_all') %></a>
+            </div>
           </div>
           <div class="l-2col-side">
             <%= template.cta_links_component %>

--- a/app/views/styleguide/latestnews.html.erb
+++ b/app/views/styleguide/latestnews.html.erb
@@ -43,3 +43,49 @@
     </div>
   </div>
 </xmp>
+
+<h3 class="styleguide__subheading">Snippet news list</h3>
+<div class="styleguide__example">
+  <div class="latest-news__snippet">
+    <ul class="latest-news__list">
+      <%- 3.times.each do |_| %>
+        <li class="latest-news__list-item">
+          <div class="latest-news__item-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" class="latest-news__icon svg-icon svg-icon--latest-news" focusable="false">
+              <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--latest-news"></use>
+            </svg>
+          </div>
+          <div class="latest-news__content">
+            <p class="latest-news__list-item__date">2 November 2017</p>
+            <p class="latest-news__list-item__text">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi a felis arcu.
+            </p>
+            <a href="http://www.fincap.org.uk" class="latest-news__list-item__cta">Read more</a>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+
+<h3 class="styleguide__subheading">Code</h3>
+<xmp>
+  <div class="latest-news__snippet">
+    <ul class="latest-news__list">
+      <li class="latest-news__list-item">
+        <div class="latest-news__item-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" class="latest-news__icon svg-icon svg-icon--latest-news" focusable="false">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--latest-news"></use>
+          </svg>
+        </div>
+        <div class="latest-news__content">
+          <p class="latest-news__list-item__date">2 November 2017</p>
+          <p class="latest-news__list-item__text">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi a felis arcu.
+          </p>
+          <a href="http://www.fincap.org.uk" class="latest-news__list-item__cta">Read more</a>
+        </div>
+      </li>
+    </ul>
+  </div>
+</xmp>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,3 +138,6 @@ en:
       thematic_review:
         message_box_info: 'You are viewing the relevant evidence summaries for thematic review: %{link}'
         evidence_hub_direct: 'Not what you were looking for? Go to %{link} for more information'
+    news:
+      more_individual: "Read more" 
+      more_all: "Find more news"    

--- a/features/step_definitions/latest_news_page_steps.rb
+++ b/features/step_definitions/latest_news_page_steps.rb
@@ -14,8 +14,8 @@ Then('I should see a list of all news article titles and dates') do |table|
   expect(latest_news_page.news_items.count).to eq(1)
 
   table.rows.each do |row|
-    expect(latest_news_page.news_items.first.text).to eq("#{row[0]} #{row[1]}")
-    expect(latest_news_page.news_items.first.link.text).to eq(row[1])
+    expect(latest_news_page.news_items.first.text).to eq("#{row[0]} #{row[1]} Read more")
+    expect(latest_news_page.news_items.first.link.text).to eq("Read more")
   end
 end
 

--- a/spec/presenters/latest_news_template_presenter_spec.rb
+++ b/spec/presenters/latest_news_template_presenter_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe LatestNewsTemplatePresenter do
+  let(:view) { ActionView::Base.new }
+  let(:object) { double('BaseTemplate', attributes) }
+  let(:attributes) { {} }
+  subject(:presenter) { described_class.new(object, view) }
+
+  describe '#hero_colour_css_class' do
+    it 'returns the css class to specify the colour' do
+      expect(presenter.hero_colour_css_class).to eq('hero--orange')
+    end
+  end
+end


### PR DESCRIPTION
[TP9305](https://moneyadviceservice.tpondemand.com/entity/9305-latest-news-view)

This PR adds a snippet variation of the latest news list to the styleguide
And then adds the styling for this into the news page

**NOTE:** The margins on the latest news list on the news page are not the same as the design. This is due to [TP9298](https://moneyadviceservice.tpondemand.com/entity/9298-apply-consistent-margins) which addresses the inconsistencies  in the margins

<img width="627" alt="screen shot 2018-07-06 at 09 02 56" src="https://user-images.githubusercontent.com/3898629/42367232-6f438f52-80fb-11e8-9228-adeb149f650d.png">
<img width="596" alt="screen shot 2018-07-06 at 09 03 05" src="https://user-images.githubusercontent.com/3898629/42367233-6f586f76-80fb-11e8-9bce-07be1d1e6448.png">
