### PR TITLE
[DEV APPROVED] - 9203 CSS Prefix in SASS build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.4.2'
 
 gem 'rails', '~> 5.0.6'
 
+gem 'autoprefixer-rails'
 gem 'dough-ruby', '~> 5.27'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (7.1.4)
     ast (2.4.0)
+    autoprefixer-rails (8.6.5)
+      execjs
     backports (3.11.1)
     bindex (0.5.0)
     bowndler (1.0.2)
@@ -321,6 +323,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer-rails
   bowndler (~> 1.0)
   brakeman
   capybara

--- a/config/autoprefixer.yml
+++ b/config/autoprefixer.yml
@@ -1,0 +1,4 @@
+#Use `rake autoprefixer:info` to see what will be prefixed
+#Use `rake tmp:clear` if update not being applied
+    browsers:
+      - "IE > 8"


### PR DESCRIPTION
[TP9203](https://moneyadviceservice.tpondemand.com/entity/9203-add-prefixing-to-the-sass-compilation)

This PR adds the [autoprefixer-rails](https://github.com/ai/autoprefixer-rails/blob/master/README.md) gem which adds prefixing to any properties needed for our config (ie 9 and above) as based on [Can I use](https://caniuse.com/)

Use `rake autoprefixer:info` to see what will be prefixed
Use `rake tmp:clear` if update not being applied

To test, check that a property listed in the info rake is receiving prefixes. E.g. .header-content flex property