### PR TITLE
Remove test that relies on local file

### DIFF
--- a/features/lifestage_page.feature
+++ b/features/lifestage_page.feature
@@ -17,10 +17,10 @@ Feature: Lifestage page
     """
     And I should see the latest news box
     And I should see the teaser boxes with
-      | image                              | title                       | text                                              | link |
-      | /assets/styleguide/hero-sample.jpg | Some title to tease you     | Loads of content to make you read more            | #    |
-      | /assets/styleguide/hero-sample.jpg | Another title to entice you | A bunch of well written content to make you click | #    |
-      | /assets/styleguide/hero-sample.jpg | Teasing title               | You want to read this, you need to read this      | #    |
+      | title                       | text                                              | link |
+      | Some title to tease you     | Loads of content to make you read more            | #    |
+      | Another title to entice you | A bunch of well written content to make you click | #    |
+      | Teasing title               | You want to read this, you need to read this      | #    |
     And I should see the research box
     And I should see the strategy box with
       | title            | text                                                     | link                               |

--- a/features/step_definitions/lifestage_steps.rb
+++ b/features/step_definitions/lifestage_steps.rb
@@ -22,10 +22,9 @@ Then('I should see the teaser boxes with') do |table|
   teasers = lifestage_page.teaser_boxes
 
   table.rows.each do |row|
-    expect(row[0]).to be_in(teasers.map { |teaser| teaser.image['src'].chomp! })
-    expect(row[1]).to be_in(teasers.map { |teaser| teaser.title.text })
-    expect(row[2]).to be_in(teasers.map { |teaser| teaser.content.text })
-    expect(row[3]).to be_in(teasers.map { |teaser| teaser.link['href'] })
+    expect(row[0]).to be_in(teasers.map { |teaser| teaser.title.text })
+    expect(row[1]).to be_in(teasers.map { |teaser| teaser.content.text })
+    expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
   end
 end
 


### PR DESCRIPTION
Does what it says on the tin. Because it refers to a local file, its failing on Go. It can be removed as the rest of the step satisfactorily tests the feature.