### PR TITLE
[DEV APPROVED] 9244 regional strategy page view

### DIFF
--- a/app/assets/stylesheets/base/_body.scss
+++ b/app/assets/stylesheets/base/_body.scss
@@ -4,7 +4,7 @@ body {
 
 .body-content {
   @extend .l-constrained;
-  margin: $baseline-spacing 0;
+  margin: $baseline-spacing auto;
   ul {
     list-style: inherit;
     list-style-position: inside;

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -58,8 +58,6 @@
 
 // Footer contact
 .footer__box {
-  margin-top: $baseline-spacing;
-
   @include respond-to($mq-m) {
     @include column(4);
     float: right;

--- a/app/assets/stylesheets/components/_list.scss
+++ b/app/assets/stylesheets/components/_list.scss
@@ -1,5 +1,8 @@
 .list {
-  list-style: none;
+  &,
+  .body-content & { 
+    list-style: none;
+  }
 
   li {
     &::before {
@@ -141,9 +144,12 @@
 
   .list--lettered-item {
     @extend %clearfix;
-    list-style: none;
     padding-bottom: $baseline-unit*4;
     position: relative;
+    &,
+    .body-content & { 
+      list-style: none;
+    }
 
     &:before {
       content: '';

--- a/app/assets/stylesheets/components/nav/_nav_level_2.scss
+++ b/app/assets/stylesheets/components/nav/_nav_level_2.scss
@@ -46,7 +46,7 @@
   @extend %l-constrained__np;
 
   @include respond-to($mq-m) {
-    @include constrained;
+    padding: 0 $baseline-spacing;
   }
 }
 

--- a/app/assets/stylesheets/components/ui/_bordered_box.scss
+++ b/app/assets/stylesheets/components/ui/_bordered_box.scss
@@ -1,10 +1,6 @@
 .bordered-box {
   @include column(12);
-  padding-bottom: $baseline-unit*2;
-
-  &:last-of-type {
-    margin-bottom: 0;
-  }
+  margin-bottom: $baseline_spacing;
 }
 
 .bordered-box__group {

--- a/app/assets/stylesheets/components/ui/_download_box.scss
+++ b/app/assets/stylesheets/components/ui/_download_box.scss
@@ -1,5 +1,4 @@
 .download-box {
-  @extend %vertical-spacing;
   background-color: $primary-green-pale;
   padding: $baseline-unit*2;
   color: $color-white;
@@ -18,9 +17,12 @@
 }
 
 .download-box__list {
-  list-style: none;
   padding: 0;
   margin-bottom: 0;
+  &,
+  .body-content & { 
+    list-style: none;
+  }
 }
 
 a.download-box__list-item-link {

--- a/app/assets/stylesheets/components/ui/_teaser.scss
+++ b/app/assets/stylesheets/components/ui/_teaser.scss
@@ -7,16 +7,9 @@
 
 .teaser-box__group-title {
   @include body(22, 24);
-  margin: 0 $baseline-unit*2 $baseline-unit*2;
+  margin: 0 $baseline-unit $baseline-unit*2;
 }
 
-.teaser-box__group-content {
-  @include respond-to($mq-s) {
-    .object-fit & {
-      display: flex;
-    }
-  }
-}
 
 .teaser-box {
   margin-bottom: $baseline-unit*2;
@@ -36,6 +29,14 @@
   }
 }
 
+.teaser-box__group-content {
+  @include respond-to($mq-s) {
+    .object-fit & {
+      display: flex;
+    }
+  }
+}
+
 .teaser-box__image {
   @include column(12);
 
@@ -44,15 +45,23 @@
   }
 }
 
-.teaser-box__title {
-  margin: $baseline-unit*2 $baseline-unit $baseline-unit;
-}
-
 .teaser-box__content {
   @include column(12);
+  padding: $baseline-unit*2 $baseline-unit;
+  .object-fit & {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 2;
+  }
+}
+
+.teaser-box__title {
+  margin-bottom: $baseline-unit;
+}
+
+.teaser-box__content-text { 
   @include body(14, 22);
-  margin: 0 $baseline-unit $baseline-unit*2 $baseline-unit;
-  padding: 0;
+  margin: 0 0 $baseline-unit*2;   
 
   .object-fit & {
     flex: 1 0 auto;
@@ -63,7 +72,6 @@
 .teaser-box__cta {
   @include body(14, 24);
   display: block;
-  margin: $baseline-unit;
   padding: $baseline-unit/2;
 }
 
@@ -80,9 +88,6 @@
   }
 
   .teaser-box__image {
-    @include column(12);
-    float: left;
-
     @include respond-to($mq-m) {
       width: 50%;
 
@@ -93,27 +98,13 @@
   }
 
   .teaser-box__content {
-    @include column(12);
-    padding: 0 $baseline-spacing;
+    padding: $baseline-unit*2 $baseline-unit*2;
 
     @include respond-to($mq-m) {
       .object-fit & {
         flex: 1;
       }
     }
-  }
-
-  .teaser-box__title {
-    margin: $baseline-spacing 0 0;
-  }
-
-  .teaser-box__content-text { 
-    margin-top: 0;   
-    padding: $baseline-unit 0;
-  }
-
-  .teaser-box__cta {
-    margin: $baseline-unit 0;
   }
 }
 

--- a/app/assets/stylesheets/layout/common/_2_col.scss
+++ b/app/assets/stylesheets/layout/common/_2_col.scss
@@ -7,8 +7,10 @@
 
 .l-2col-side {
   @include column(12);
+
   @include respond-to($mq-m) {
     @include column(4);
+
     .l-2col-no-margin & {
       @include column(4, 2);
     }
@@ -17,8 +19,10 @@
 
 .l-2col-main {
   @include column(12);
+
   @include respond-to($mq-m) {
     @include column(8);
+
     .l-2col-no-margin & {
       @include column(8, 2);
     }
@@ -27,8 +31,10 @@
 
 .l-2col-even {
   @include column(12);
+
   @include respond-to($mq-m) {
     @include column(6);
+
     .l-2col-no-margin & {
       @include column(6, 2);
     }

--- a/app/assets/stylesheets/layout/common/_3_col.scss
+++ b/app/assets/stylesheets/layout/common/_3_col.scss
@@ -10,10 +10,7 @@
   @include column(12);
 
   @include respond-to($mq-m) {
-    @include column(4);
-    .l-2col-no-margin & {
-      @include column(4, 3);
-    }
+    @include column(4, 3);
   }
 }
 

--- a/app/controllers/regional_strategies_controller.rb
+++ b/app/controllers/regional_strategies_controller.rb
@@ -11,5 +11,4 @@ class RegionalStrategiesController < FincapTemplatesController
     RegionalStrategyTemplate.new(@regional_strategy)
   end
   helper_method :resource
-
 end

--- a/app/controllers/regional_strategies_controller.rb
+++ b/app/controllers/regional_strategies_controller.rb
@@ -1,0 +1,15 @@
+class RegionalStrategiesController < FincapTemplatesController
+  def show
+    @regional_strategy = Mas::Cms::RegionalStrategy.find(params[:id])
+
+    @latest_news = TaggedNews.all(@regional_strategy).map do |news|
+      NewsTemplate.new(news)
+    end
+  end
+
+  def resource
+    RegionalStrategyTemplate.new(@regional_strategy)
+  end
+  helper_method :resource
+
+end

--- a/app/presenters/article_template_presenter.rb
+++ b/app/presenters/article_template_presenter.rb
@@ -1,2 +1,25 @@
 class ArticleTemplatePresenter < TemplatePresenter
+  def strategy_title_component
+    view.strip_tags(strategy_title_block.try(:content).to_s)
+  end
+
+  def strategy_link_component
+    extract_links(strategy_link_block.try(:content).to_s)
+  end
+
+  def teaser_section_title_component
+    view.strip_tags(teaser_section_title_block.try(:content).to_s)
+  end
+
+  def teaser_image_component(number)
+    view.strip_tags(teaser_image_block(number).try(:content).to_s)
+  end
+
+  def teaser_text_component(number)
+    view.strip_tags(teaser_text_block(number).try(:content).to_s)
+  end
+
+  def teaser_title_component(number)
+    view.strip_tags(teaser_title_block(number).try(:content).to_s)
+  end
 end

--- a/app/presenters/lifestage_template_presenter.rb
+++ b/app/presenters/lifestage_template_presenter.rb
@@ -1,4 +1,4 @@
-class LifestageTemplatePresenter < TemplatePresenter
+class LifestageTemplatePresenter < ArticleTemplatePresenter
   def steering_group_title_component
     view.strip_tags(steering_group_title_block.try(:content).to_s)
   end
@@ -7,37 +7,7 @@ class LifestageTemplatePresenter < TemplatePresenter
     extract_links(steering_group_links_block.try(:content).to_s)
   end
 
-  def strategy_title_component
-    view.strip_tags(strategy_title_block.try(:content).to_s)
-  end
-
   def strategy_overview_component
     view.strip_tags(strategy_overview_block.try(:content).to_s)
-  end
-
-  def strategy_link_component
-    extract_links(strategy_link_block.try(:content).to_s)
-  end
-
-  def teaser_section_title_component
-    view.strip_tags(teaser_section_title_block.try(:content).to_s)
-  end
-
-  def teaser_image_component(number)
-    view.strip_tags(teaser_image_block(number).try(:content).to_s)
-  end
-
-  def teaser_text_component(number)
-    view.strip_tags(teaser_text_block(number).try(:content).to_s)
-  end
-
-  def teaser_title_component(number)
-    view.strip_tags(teaser_title_block(number).try(:content).to_s)
-  end
-
-  private
-
-  def extract_links(html_string)
-    HtmlParser.new(html_string).extract_links
   end
 end

--- a/app/presenters/news_template_presenter.rb
+++ b/app/presenters/news_template_presenter.rb
@@ -1,4 +1,4 @@
-class NewsTemplatePresenter < TemplatePresenter
+class NewsTemplatePresenter < ArticleTemplatePresenter
   def order_by_date_component
     format_date(
       view.strip_tags(order_by_date_block.try(:content))
@@ -13,9 +13,5 @@ class NewsTemplatePresenter < TemplatePresenter
 
   def format_date(date_string)
     date_string ? view.l(date_string.to_s.to_date, format: :to_word) : ''
-  end
-
-  def extract_links(html_string)
-    HtmlParser.new(html_string).extract_links
   end
 end

--- a/app/presenters/regional_strategy_template_presenter.rb
+++ b/app/presenters/regional_strategy_template_presenter.rb
@@ -1,0 +1,13 @@
+class RegionalStrategyTemplatePresenter < ArticleTemplatePresenter
+  def forum_title_component
+    view.strip_tags(forum_title_block.try(:content).to_s)
+  end
+
+  def forum_links_component
+    extract_links(forum_links_block.try(:content).to_s)
+  end
+
+  def strategy_text_component
+    view.strip_tags(strategy_text_block.try(:content).to_s)
+  end
+end

--- a/app/presenters/template_presenter.rb
+++ b/app/presenters/template_presenter.rb
@@ -23,6 +23,12 @@ class TemplatePresenter < BasePresenter
     view.strip_tags(overview_block.try(:content).to_s)
   end
 
+  protected
+
+  def extract_links(html_string)
+    HtmlParser.new(html_string).extract_links
+  end
+
   private
 
   def download_content

--- a/app/templates/article_template.rb
+++ b/app/templates/article_template.rb
@@ -1,2 +1,34 @@
 class ArticleTemplate < BaseTemplate
+  STRATEGY_TITLE_ID = 'strategy_title'.freeze
+  STRATEGY_LINK_ID = 'strategy_link'.freeze
+  TEASER_SECTION_TITLE_ID = 'teaser_section_title'.freeze
+  TEASER_BOX_PREFIX = 'teaser'.freeze
+
+  def strategy_title_block
+    find_block(STRATEGY_TITLE_ID)
+  end
+
+  def strategy_link_block
+    find_block(STRATEGY_LINK_ID)
+  end
+
+  def teaser_section_title_block
+    find_block(TEASER_SECTION_TITLE_ID)
+  end
+
+  def teaser_image_block(number)
+    find_block("#{TEASER_BOX_PREFIX}#{number}_image")
+  end
+
+  def teaser_link_block(number)
+    find_block("#{TEASER_BOX_PREFIX}#{number}_link")
+  end
+
+  def teaser_text_block(number)
+    find_block("#{TEASER_BOX_PREFIX}#{number}_text")
+  end
+
+  def teaser_title_block(number)
+    find_block("#{TEASER_BOX_PREFIX}#{number}_title")
+  end
 end

--- a/app/templates/base_template.rb
+++ b/app/templates/base_template.rb
@@ -10,6 +10,7 @@ class BaseTemplate
            :body,
            :non_content_blocks,
            :full_path,
+           :slug,
            to: :article
 
   attr_reader :article

--- a/app/templates/lifestage_template.rb
+++ b/app/templates/lifestage_template.rb
@@ -1,11 +1,7 @@
-class LifestageTemplate < BaseTemplate
+class LifestageTemplate < ArticleTemplate
   STEERING_GROUP_TITLE_ID = 'steering_group_title'.freeze
   STEERING_GROUP_LINKS_ID = 'steering_group_links'.freeze
-  STRATEGY_TITLE_ID = 'strategy_title'.freeze
   STRATEGY_OVERVIEW_ID = 'strategy_overview'.freeze
-  STRATEGY_LINK_ID = 'strategy_link'.freeze
-  TEASER_SECTION_TITLE_ID = 'teaser_section_title'.freeze
-  TEASER_BOX_PREFIX = 'teaser'.freeze
 
   def steering_group_title_block
     find_block(STEERING_GROUP_TITLE_ID)
@@ -15,35 +11,7 @@ class LifestageTemplate < BaseTemplate
     find_block(STEERING_GROUP_LINKS_ID)
   end
 
-  def strategy_title_block
-    find_block(STRATEGY_TITLE_ID)
-  end
-
   def strategy_overview_block
     find_block(STRATEGY_OVERVIEW_ID)
-  end
-
-  def strategy_link_block
-    find_block(STRATEGY_LINK_ID)
-  end
-
-  def teaser_section_title_block
-    find_block(TEASER_SECTION_TITLE_ID)
-  end
-
-  def teaser_image_block(number)
-    find_block("#{TEASER_BOX_PREFIX}#{number}_image")
-  end
-
-  def teaser_link_block(number)
-    find_block("#{TEASER_BOX_PREFIX}#{number}_link")
-  end
-
-  def teaser_text_block(number)
-    find_block("#{TEASER_BOX_PREFIX}#{number}_text")
-  end
-
-  def teaser_title_block(number)
-    find_block("#{TEASER_BOX_PREFIX}#{number}_title")
   end
 end

--- a/app/templates/regional_strategy_template.rb
+++ b/app/templates/regional_strategy_template.rb
@@ -1,0 +1,17 @@
+class RegionalStrategyTemplate < ArticleTemplate
+  FORUM_TITLE_ID = 'forum_title'.freeze
+  FORUM_LINKS_ID = 'forum_links'.freeze
+  STRATEGY_TEXT_ID = 'strategy_text'.freeze
+
+  def forum_title_block
+    find_block(FORUM_TITLE_ID)
+  end
+
+  def forum_links_block
+    find_block(FORUM_LINKS_ID)
+  end
+
+  def strategy_text_block
+    find_block(STRATEGY_TEXT_ID)
+  end
+end

--- a/app/views/lifestages/_supplementary_content.html.erb
+++ b/app/views/lifestages/_supplementary_content.html.erb
@@ -1,10 +1,8 @@
 <div class="sidepanel">
   <div class="l-2col-even">
-    <h2 class="sidepanel__title">
-      <%= template.strategy_title_component %>
-    </h2>
-    <p><%= template.strategy_overview_component %></p>
-    <% template.strategy_link_component.each do |link| %>
+    <h2 class="sidepanel__title"><%= strategy_title %></h2>
+    <p><%= strategy_content %></p>
+    <% strategy_links.each do |link| %>
       <a href="<%= link[:href] %>" class="btn btn--secondary btn--full-width">
         <%= link[:text] %>
       </a>
@@ -12,14 +10,10 @@
   </div>
 
   <div class="l-2col-even">
-    <h2 class="sidepanel__title">
-      <%= template.steering_group_title_component %>
-    </h2>
+    <h2 class="sidepanel__title"><%= working_group_title %></h2>
     <ul class="list list--links">
-      <%- template.steering_group_links_component.each do |link| %>
-        <li>
-          <a href="<%= link[:href] %>"><%= link[:text] %></a>
-        </li>
+      <%- working_group_links.each do |link| %>
+        <li><a href="<%= link[:href] %>"><%= link[:text] %></a></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/lifestages/_teaser_box.html.erb
+++ b/app/views/lifestages/_teaser_box.html.erb
@@ -1,8 +1,10 @@
 <div class="teaser-box">
   <img src="<%= image %>" class="teaser-box__image" />
-  <h3 class="teaser-box__title"><%= title %></h3>
-  <p class="teaser-box__content"><%= text %></p>
-  <a href="#" class="teaser-box__cta btn btn--primary">
-    Call to action
-  </a>
+  <div class="teaser-box__content">
+    <h3 class="teaser-box__title"><%= title %></h3>
+    <p class="teaser-box__content-text"><%= text %></p>
+    <a href="#" class="teaser-box__cta btn btn--primary">
+      Call to action
+    </a>
+  </div>
 </div>

--- a/app/views/lifestages/show.html.erb
+++ b/app/views/lifestages/show.html.erb
@@ -34,32 +34,36 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="l-constrained">
-      <div class="l-2col">
-        <div class="l-2col-main">
-          <div class="row">
-            <%= render 'shared/research_and_evaluation' %>
-          </div>
-          <div class="row">
-            <div class="l-2col l-2col-no-margin">
-              <%= render 'lifestages/supplementary_content', template: template %>
-            </div>
-          </div>
+
+  <div class="l-constrained">
+    <div class="l-2col">
+      <div class="l-2col-main">
+        <div class="row">
+          <%= render 'shared/research_and_evaluation' %>
         </div>
-        <div class="l-2col-side">
-          <div class="row">
-            <%= render "shared/life_stages" %>
+        <div class="row">
+          <div class="l-2col l-2col-no-margin">
+            <%= render 'lifestages/supplementary_content', template: template,
+              strategy_title: template.strategy_title_component,
+              strategy_content: template.strategy_overview_component,
+              strategy_links: template.strategy_link_component,
+              working_group_title: template.steering_group_title_component,
+              working_group_links: template.steering_group_links_component
+            %>
           </div>
         </div>
       </div>
+      <div class="l-2col-side">
+        <div class="row">
+          <%= render "shared/life_stages" %>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="l-constrained">
-    <div class= "l-2col">
+
+    <div class= "row l-2col">
       <div class="l-2col-main">
         <%= template.download_component %>
       </div>
     </div>
-  </div>
+</div>
 <% end %>

--- a/app/views/regional_strategies/show.html.erb
+++ b/app/views/regional_strategies/show.html.erb
@@ -1,0 +1,64 @@
+<% present(resource) do |template| %>
+  <div class="l-constrained">
+    <%= render "/components/hero",
+      img_src: template.hero_image_component,
+      description: template.hero_description_component
+    %>
+  </div>
+  <div class="l-constrained">
+    <div class="l-2col">
+      <div class="l-2col-main">
+        <h1><%= template.title %></h1>
+        <%= template.body.html_safe %>
+        <%= render 'shared/research_and_evaluation' %>
+      </div>
+      <div class="l-2col-side">
+        <%= render "shared/latest_news", latest_news: @latest_news %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="l-constrained">
+      <div class="l-3col-even">
+        <h3><%= template.strategy_title_component %></h3>
+        <p><%= template.strategy_text_component %></p>
+      </div>
+      <div class="l-3col-even">
+        <h3><%= template.forum_title_component %></h3>
+        <ul class="list list--links">
+          <% template.forum_links_component.each do |link| %>
+            <li><%= link_to link[:text], link[:href] %></li>
+          <% end %>
+        </ul>
+      </div>
+      <div class="l-3col-even">
+        <h3><%= render 'shared/country_list' %></h3>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="l-constrained">
+      <div class="teaser-box__group">
+        <h2 class="teaser-box__group-title">
+          <%= template.teaser_section_title_component %>
+        </h2>
+        <div class="teaser-box__group-content">
+          <% (1..3).each do |n| %>
+            <%= render "lifestages/teaser_box",
+              image: template.teaser_image_component(n),
+              title: template.teaser_title_component(n),
+              text: template.teaser_text_component(n)
+            %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+   <div class="l-constrained">
+    <div class= "l-2col">
+      <div class="l-2col-main">
+        <%= template.download_component %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/regional_strategies/show.html.erb
+++ b/app/views/regional_strategies/show.html.erb
@@ -14,23 +14,16 @@
           <%= template.body.html_safe %>
         </div>
         <%= render 'shared/research_and_evaluation' %>
-
-        <div class="row bordered-box">
-          <div class="l-2col bordered-box__inner">
-            <div class="bordered-box__content">
-              <div class="l-2col-even">
-                <h3><%= template.strategy_title_component %></h3>
-                <p><%= template.strategy_text_component %></p>
-              </div>
-              <div class="l-2col-even">
-                <h3><%= template.forum_title_component %></h3>
-                <ul class="list list--links">
-                  <% template.forum_links_component.each do |link| %>
-                    <li><%= link_to link[:text], link[:href] %></li>
-                  <% end %>
-                </ul>
-              </div>
-            </div>
+        
+        <div class="row">
+          <div class="l-2col l-2col-no-margin">
+            <%= render 'lifestages/supplementary_content', template: template,
+              strategy_title: template.strategy_title_component,
+              strategy_content: template.strategy_text_component,
+              strategy_links: template.strategy_link_component,
+              working_group_title: template.forum_title_component,
+              working_group_links: template.forum_links_component
+            %>
           </div>
         </div>
 

--- a/app/views/regional_strategies/show.html.erb
+++ b/app/views/regional_strategies/show.html.erb
@@ -2,42 +2,47 @@
   <div class="l-constrained">
     <%= render "/components/hero",
       img_src: template.hero_image_component,
-      description: template.hero_description_component
+      description: template.hero_description_component,
+      hero_colour: "hero--yellow"
     %>
   </div>
   <div class="l-constrained">
     <div class="l-2col">
       <div class="l-2col-main">
-        <h1><%= template.title %></h1>
-        <%= template.body.html_safe %>
+        <div class="body-content">
+          <h1><%= template.title %></h1>
+          <%= template.body.html_safe %>
+        </div>
         <%= render 'shared/research_and_evaluation' %>
+
+        <div class="row bordered-box">
+          <div class="l-2col bordered-box__inner">
+            <div class="bordered-box__content">
+              <div class="l-2col-even">
+                <h3><%= template.strategy_title_component %></h3>
+                <p><%= template.strategy_text_component %></p>
+              </div>
+              <div class="l-2col-even">
+                <h3><%= template.forum_title_component %></h3>
+                <ul class="list list--links">
+                  <% template.forum_links_component.each do |link| %>
+                    <li><%= link_to link[:text], link[:href] %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
       </div>
       <div class="l-2col-side">
         <%= render "shared/latest_news", latest_news: @latest_news %>
+        <%= render 'shared/country_list' %>
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="l-constrained">
-      <div class="l-3col-even">
-        <h3><%= template.strategy_title_component %></h3>
-        <p><%= template.strategy_text_component %></p>
-      </div>
-      <div class="l-3col-even">
-        <h3><%= template.forum_title_component %></h3>
-        <ul class="list list--links">
-          <% template.forum_links_component.each do |link| %>
-            <li><%= link_to link[:text], link[:href] %></li>
-          <% end %>
-        </ul>
-      </div>
-      <div class="l-3col-even">
-        <h3><%= render 'shared/country_list' %></h3>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="l-constrained">
+  <div class="l-constrained">
+    <div class="row">
       <div class="teaser-box__group">
         <h2 class="teaser-box__group-title">
           <%= template.teaser_section_title_component %>
@@ -53,9 +58,8 @@
         </div>
       </div>
     </div>
-  </div>
-   <div class="l-constrained">
-    <div class= "l-2col">
+
+    <div class= "row l-2col">
       <div class="l-2col-main">
         <%= template.download_component %>
       </div>

--- a/app/views/styleguide/teaser.html.erb
+++ b/app/views/styleguide/teaser.html.erb
@@ -26,29 +26,32 @@
     <div class="teaser-box__group-content">
       <div class="teaser-box">
         <%= image_tag 'styleguide/teaser-image.png', class: 'teaser-box__image' %>
-        <h3 class="teaser-box__title">Title</h3>
-        <p class="teaser-box__content">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.
-        </p>
-        <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        <div class="teaser-box__content">
+          <h3 class="teaser-box__title">Title</h3>
+          <p class="teaser-box__content-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.</p>
+
+          <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        </div>
       </div>
 
       <div class="teaser-box">
         <%= image_tag 'styleguide/teaser-image.png', class: 'teaser-box__image' %>
-        <h3 class="teaser-box__title">Title</h3>
-        <p class="teaser-box__content">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.
-        </p>
-        <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        <div class="teaser-box__content">
+          <h3 class="teaser-box__title">Title</h3>
+          <p class="teaser-box__content-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.</p>
+
+          <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        </div>
       </div>
 
       <div class="teaser-box">
         <%= image_tag 'styleguide/teaser-image.png', class: 'teaser-box__image' %>
-        <h3 class="teaser-box__title">Title</h3>
-        <p class="teaser-box__content">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.
-        </p>
-        <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        <div class="teaser-box__content">
+          <h3 class="teaser-box__title">Title</h3>
+          <p class="teaser-box__content-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eu sagittis nisi.</p>
+
+          <a href="https://www.fincap.org.uk" class="teaser-box__cta btn btn--primary">Call to action</a>
+        </div>
       </div>
     </div>
   </div>

--- a/config/initializers/mas_cms_client.rb
+++ b/config/initializers/mas_cms_client.rb
@@ -30,6 +30,9 @@ end
 class Mas::Cms::Review < Mas::Cms::Document
 end
 
+class Mas::Cms::RegionalStrategy < Mas::Cms::Article
+end
+
 class Mas::Cms::ThematicReview < Mas::Cms::Article
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resources :insights, only: :show
     resources :lifestages, only: :show
     resources :news, only: %i[index show]
+    resources :regional_strategies, only: %i[show]
     resources :reviews, only: :show
     resources :thematic_reviews, only: %i[index show]
 

--- a/features/lifestage_page.feature
+++ b/features/lifestage_page.feature
@@ -34,7 +34,6 @@ Feature: Lifestage page
       | Steering group members | /financial+capability+strategy.pdf |
       | Steering group updates | /financial+capability+strategy.pdf |
       | Action plans           | /financial+capability+strategy.pdf |
-    And I should see the lifestage download links
+    And I should see the download links
       | text                  | link                               |
       | Young Adults download | /financial+capability+strategy.pdf |
-      

--- a/features/regional_strategy_page.feature
+++ b/features/regional_strategy_page.feature
@@ -1,0 +1,37 @@
+Feature: Regional Strategy page
+  As a user, 
+  I want to be able to read a regional strategy page and easily find related content, 
+  so that I can gather as much information as I require on this subject.
+
+  Scenario: Visiting an Regional Strategy page
+    Given I entered into the Regional Strategy page "Wales"
+    Then I should see the regional strategy title "Wales"
+    And I should see the regional strategy description
+    """
+    Research suggests that young adults typically display
+    lower levels of financial capability than older age groups.
+    """
+    And I should see the regional strategy content
+    """
+    Young adults, as they leave school or other statutory settings, will face major changes in the coming years to the policy, economic and social landscape within which they will start managing money day to day and making critical financial decisions about their future. The degree of financial capability they display during this transition can have a major bearing on their resilience and wellbeing throughout their adult lives.
+    """
+    And I should see the latest news box
+    And I should see the teaser boxes with
+      | title                       | text                                              | link |
+      | Some title to tease you     | Loads of content to make you read more            | #    |
+      | Another title to entice you | A bunch of well written content to make you click | #    |
+      | Teasing title               | You want to read this, you need to read this      | #    |
+    And I should see the research box
+    And I should see the strategy box with
+      | title            | text                                                     | link                               |
+      | Strategy extract | Young adults in the coming years will face major changes | /financial+capability+strategy.pdf | 
+    And I should see the lifestages box
+    And I should see the steering group links
+      | text                   | link                               |
+      | Steering group members | /financial+capability+strategy.pdf |
+      | Steering group updates | /financial+capability+strategy.pdf |
+      | Action plans           | /financial+capability+strategy.pdf |
+    And I should see the lifestage download links
+      | text                  | link                               |
+      | Young Adults download | /financial+capability+strategy.pdf |
+      

--- a/features/regional_strategy_page.feature
+++ b/features/regional_strategy_page.feature
@@ -8,30 +8,24 @@ Feature: Regional Strategy page
     Then I should see the regional strategy title "Wales"
     And I should see the regional strategy description
     """
-    Research suggests that young adults typically display
-    lower levels of financial capability than older age groups.
+    The Welsh Government has long recognised that financial exclusion 
+    and over-indebtedness are issues that need concerted action
     """
     And I should see the regional strategy content
     """
-    Young adults, as they leave school or other statutory settings, will face major changes in the coming years to the policy, economic and social landscape within which they will start managing money day to day and making critical financial decisions about their future. The degree of financial capability they display during this transition can have a major bearing on their resilience and wellbeing throughout their adult lives.
+    The usually resident population of Wales was 3.1 million people living in 1.3 million households in 2011, with nearly one in five of residents aged 65 or over. Wales had a higher percentage of residents with a long-term health problem or disability. One in four of those aged 16 and over reported having no recognised qualification. There are 700,000 people in poverty in Wales, equivalent to 23 per cent of the population.
     """
     And I should see the latest news box
     And I should see the teaser boxes with
-      | title                       | text                                              | link |
-      | Some title to tease you     | Loads of content to make you read more            | #    |
-      | Another title to entice you | A bunch of well written content to make you click | #    |
-      | Teasing title               | You want to read this, you need to read this      | #    |
+      | title                     | text                                                                                                                        | link |
+      | Child Poverty Strategy    | New objectives for improving the outcomes of children and young people living in low income households.                     | #    |
+      | Strategy for Older People | Delivery Action Plan for Living Longer, Living Better focuses on the three priorities for the Strategy for Older People.    | #    |
+      | Warm Homes programme      | The government has made considerable investment to address home energy efficiency in low income communities and households. | #    |
     And I should see the research box
     And I should see the strategy box with
-      | title            | text                                                     | link                               |
-      | Strategy extract | Young adults in the coming years will face major changes | /financial+capability+strategy.pdf | 
-    And I should see the lifestages box
-    And I should see the steering group links
-      | text                   | link                               |
-      | Steering group members | /financial+capability+strategy.pdf |
-      | Steering group updates | /financial+capability+strategy.pdf |
-      | Action plans           | /financial+capability+strategy.pdf |
-    And I should see the lifestage download links
+      | title                               | text                                                                    | link                               |
+      | Wales Financial Capability Strategy | There is general agreement that there should be one Strategy for Wales. | /financial+capability+strategy.pdf | 
+    And I should see the countries box
+    And I should see the download links
       | text                  | link                               |
       | Young Adults download | /financial+capability+strategy.pdf |
-      

--- a/features/step_definitions/latest_news_component_steps.rb
+++ b/features/step_definitions/latest_news_component_steps.rb
@@ -1,3 +1,12 @@
 Then('I should see the latest news box with {string} news items') do |number|
   expect(current_page.latest_news_item.count).to eq(number.to_i)
 end
+
+Then('I should see the news items details') do |table|
+  news_items = current_page.latest_news_item
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(news_items.map { |item| item.title.text })
+    expect(row[1]).to be_in(news_items.map { |item| item.date.text })
+  end
+end

--- a/features/step_definitions/lifestage_steps.rb
+++ b/features/step_definitions/lifestage_steps.rb
@@ -10,31 +10,6 @@ Then('I should see the lifestage content') do |content|
   expect(lifestage_page.main_content.first).to have_content(content)
 end
 
-Then('I should see the teaser boxes with') do |table|
-  teasers = lifestage_page.teaser_boxes
-
-  table.rows.each do |row|
-    expect(row[0]).to be_in(teasers.map { |teaser| teaser.title.text })
-    expect(row[1]).to be_in(teasers.map { |teaser| teaser.content.text })
-    expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
-  end
-end
-
-Then('I should see the research box') do
-  expect(lifestage_page).to have_content('Research and findings')
-  expect(lifestage_page).to have_content('Evaluate your programme')
-end
-
-Then('I should see the strategy box with') do |table|
-  strategy_box = lifestage_page.supplementary_info_box.first
-
-  table.rows.each do |row|
-    expect(row[0]).to eq(strategy_box.title.text)
-    expect(strategy_box.content).to have_content(row[1])
-    expect(row[2]).to be_in(strategy_box.links.map { |link| link[:href] })
-  end
-end
-
 Then('I should see the lifestages box') do
   expect(lifestage_page).to have_content('Life stages across the UK')
 end
@@ -45,14 +20,5 @@ Then('I should see the steering group links') do |table|
   table.rows.each do |row|
     expect(row[0]).to be_in(links.map(&:text))
     expect(row[1]).to be_in(links.map { |link| link[:href] })
-  end
-end
-
-Then('I should see the lifestage download links') do |table|
-  download_box_links = lifestage_page.download_box.map(&:link)
-
-  table.rows.each do |row|
-    expect(row[0]).to be_in(download_box_links.map(&:text))
-    expect(row[1]).to be_in(download_box_links.map { |link| link[:href] })
   end
 end

--- a/features/step_definitions/regional_strategy_steps.rb
+++ b/features/step_definitions/regional_strategy_steps.rb
@@ -18,49 +18,7 @@ Then('I should see the latest news box') do
   expect(regional_strategy_page).to have_latest_news
 end
 
-Then('I should see the teaser boxes with') do |table|
-  teasers = regional_strategy_page.teaser_boxes
-
-  table.rows.each do |row|
-    expect(row[0]).to be_in(teasers.map { |teaser| teaser.title.text })
-    expect(row[1]).to be_in(teasers.map { |teaser| teaser.content.text })
-    expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
-  end
-end
-
-Then('I should see the research box') do
-  expect(regional_strategy_page).to have_content('Research and findings')
-  expect(regional_strategy_page).to have_content('Evaluate your programme')
-end
-
-Then('I should see the strategy box with') do |table|
-  strategy_box = regional_strategy_page.supplementary_info_box.first
-
-  table.rows.each do |row|
-    expect(row[0]).to eq(strategy_box.title.text)
-    expect(strategy_box.content).to have_content(row[1])
-    expect(row[2]).to be_in(strategy_box.links.map { |link| link[:href] })
-  end
-end
-
-Then('I should see the lifestages box') do
-  expect(regional_strategy_page).to have_content('Life stages across the UK')
-end
-
-Then('I should see the steering group links') do |table|
-  links = regional_strategy_page.supplementary_info_box.last.links
-
-  table.rows.each do |row|
-    expect(row[0]).to be_in(links.map(&:text))
-    expect(row[1]).to be_in(links.map { |link| link[:href] })
-  end
-end
-
-Then('I should see the lifestage download links') do |table|
-  download_box_links = regional_strategy_page.download_box.map(&:link)
-
-  table.rows.each do |row|
-    expect(row[0]).to be_in(download_box_links.map(&:text))
-    expect(row[1]).to be_in(download_box_links.map { |link| link[:href] })
-  end
+Then('I should see the countries box') do
+  expect(regional_strategy_page).to have_content('The Strategy across the UK')
+  expect(regional_strategy_page).to have_country_list
 end

--- a/features/step_definitions/regional_strategy_steps.rb
+++ b/features/step_definitions/regional_strategy_steps.rb
@@ -1,0 +1,66 @@
+Given('I entered into the Regional Strategy page {string}') do |title|
+  regional_strategy_page.load(slug: title.parameterize)
+end
+
+Then('I should see the regional strategy title {string}') do |title|
+  expect(regional_strategy_page).to have_content(title)
+end
+
+Then('I should see the regional strategy description') do |description|
+  expect(regional_strategy_page.main_description).to have_content(description)
+end
+
+Then('I should see the regional strategy content') do |content|
+  expect(regional_strategy_page).to have_content(content)
+end
+
+Then('I should see the latest news box') do
+  expect(regional_strategy_page).to have_latest_news
+end
+
+Then('I should see the teaser boxes with') do |table|
+  teasers = regional_strategy_page.teaser_boxes
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(teasers.map { |teaser| teaser.title.text })
+    expect(row[1]).to be_in(teasers.map { |teaser| teaser.content.text })
+    expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
+  end
+end
+
+Then('I should see the research box') do
+  expect(regional_strategy_page).to have_content('Research and findings')
+  expect(regional_strategy_page).to have_content('Evaluate your programme')
+end
+
+Then('I should see the strategy box with') do |table|
+  strategy_box = regional_strategy_page.supplementary_info_box.first
+
+  table.rows.each do |row|
+    expect(row[0]).to eq(strategy_box.title.text)
+    expect(strategy_box.content).to have_content(row[1])
+    expect(row[2]).to be_in(strategy_box.links.map { |link| link[:href] })
+  end
+end
+
+Then('I should see the lifestages box') do
+  expect(regional_strategy_page).to have_content('Life stages across the UK')
+end
+
+Then('I should see the steering group links') do |table|
+  links = regional_strategy_page.supplementary_info_box.last.links
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(links.map(&:text))
+    expect(row[1]).to be_in(links.map { |link| link[:href] })
+  end
+end
+
+Then('I should see the lifestage download links') do |table|
+  download_box_links = regional_strategy_page.download_box.map(&:link)
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(download_box_links.map(&:text))
+    expect(row[1]).to be_in(download_box_links.map { |link| link[:href] })
+  end
+end

--- a/features/step_definitions/shared_page_steps.rb
+++ b/features/step_definitions/shared_page_steps.rb
@@ -2,12 +2,35 @@ Then('I should see the hero description {string}') do |description|
   expect(current_page.hero_description.text).to eq(description)
 end
 
-Then('I should see the news items details') do |table|
-  news_items = current_page.latest_news_item
+Then('I should see the download links') do |table|
+  download_box_links = current_page.download_box.map(&:link)
 
   table.rows.each do |row|
-    expect(row[0]).to be_in(news_items.map { |item| item.title.text })
-    expect(row[1]).to be_in(news_items.map { |item| item.date.text })
-    expect(row[2]).to be_in(news_items.map { |item| item.link['href'] })
+    expect(row[0]).to be_in(download_box_links.map(&:text))
+    expect(row[1]).to be_in(download_box_links.map { |link| link[:href] })
+  end
+end
+
+Then('I should see the research box') do
+  expect(current_page).to have_content('Research and findings')
+  expect(current_page).to have_content('Evaluate your programme')
+end
+
+Then('I should see the strategy box with') do |table|
+  strategy_box = current_page.supplementary_info_box.first
+  table.rows.each do |row|
+    expect(row[0]).to eq(strategy_box.title.text)
+    expect(strategy_box.content).to have_content(row[1])
+    expect(row[2]).to be_in(strategy_box.links.map { |link| link[:href] })
+  end
+end
+
+Then('I should see the teaser boxes with') do |table|
+  teasers = current_page.teaser_boxes
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(teasers.map { |teaser| teaser.title.text })
+    expect(row[1]).to be_in(teasers.map { |teaser| teaser.content.text })
+    expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
   end
 end

--- a/features/support/ui/page.rb
+++ b/features/support/ui/page.rb
@@ -7,9 +7,30 @@ module UI
     element :link, '.latest-news__list-item__cta'
   end
 
-  class Page < SitePrism::Page
-    element :hero_description, '.hero__heading'
+  class DownloadBoxSection < SitePrism::Section
+    element :link, 'a'
+  end
 
+  class SupplementaryInfoBox < SitePrism::Section
+    element :title, 'h2'
+    element :content, 'p'
+    elements :links, 'a'
+  end
+
+  class TeaserBox < SitePrism::Section
+    element :title, '.teaser-box__title'
+    element :image, '.teaser-box__image'
+    element :content, '.teaser-box__content-text'
+    element :link, '.teaser-box__cta'
+  end
+
+  class Page < SitePrism::Page
+    sections :download_box,
+             DownloadBoxSection, '.download-box ul.download-box__list li'
     sections :latest_news_item, LatestNewsItem, '.latest-news__list-item'
+    sections :teaser_boxes, TeaserBox, '.teaser-box__content'
+    sections :supplementary_info_box,
+             SupplementaryInfoBox, '.sidepanel .l-2col-even'
+    element :hero_description, '.hero__heading'
   end
 end

--- a/features/support/ui/pages/article.rb
+++ b/features/support/ui/pages/article.rb
@@ -1,9 +1,5 @@
 module UI
   module Pages
-    class DownloadBoxSection < SitePrism::Section
-      element :link, 'a'
-    end
-
     class CallToActionBoxSection < SitePrism::Section
       element :link, 'a'
     end
@@ -12,9 +8,6 @@ module UI
       set_url '/en/articles/{/slug}'
 
       element :feedback_box, '.feedback-box'
-      sections :download_box,
-               DownloadBoxSection,
-               '.download-box ul.download-box__list li'
       sections :call_to_action_box,
                CallToActionBoxSection,
                '.list--grouped-cta li'

--- a/features/support/ui/pages/lifestage.rb
+++ b/features/support/ui/pages/lifestage.rb
@@ -1,25 +1,9 @@
 module UI
   module Pages
-    class TeaserBox < SitePrism::Section
-      element :title, '.teaser-box__title'
-      element :image, '.teaser-box__image'
-      element :content, '.teaser-box__content'
-      element :link, '.teaser-box__cta'
-    end
-
-    class SupplementaryInfoBox < SitePrism::Section
-      element :title, 'h2'
-      element :content, 'p'
-      elements :links, 'a'
-    end
-
     class Lifestage < ::UI::Pages::Article
       set_url '/en/lifestages/{/slug}'
 
       elements :main_content, '.l-2col-main p'
-      sections :teaser_boxes, TeaserBox, '.teaser-box'
-      sections :supplementary_info_box,
-               SupplementaryInfoBox, '.sidepanel .l-2col-even'
     end
   end
 end

--- a/features/support/ui/pages/regional_strategy.rb
+++ b/features/support/ui/pages/regional_strategy.rb
@@ -1,18 +1,5 @@
 module UI
   module Pages
-    class TeaserBox < SitePrism::Section
-      element :title, '.teaser-box__title'
-      element :image, '.teaser-box__image'
-      element :content, '.teaser-box__content'
-      element :link, '.teaser-box__cta'
-    end
-
-    class ForumBox < SitePrism::Section
-      element :title, 'h2'
-      element :content, 'p'
-      elements :links, 'a'
-    end
-
     class Countries < SitePrism::Section
       element :title, 'h2'
       element :content, 'p'
@@ -24,10 +11,7 @@ module UI
 
       element :main_description, '.hero'
       element :latest_news, '.latest-news'
-      sections :teaser_boxes, TeaserBox, '.teaser-box'
-      section :supplementary_info_box,
-               ForumBox, '.sidepanel .l-2col-even'
-      sections :countries, Countries, '.list--countries--item'
+      element :country_list, 'ul.list--countries'
     end
   end
 end

--- a/features/support/ui/pages/regional_strategy.rb
+++ b/features/support/ui/pages/regional_strategy.rb
@@ -1,0 +1,33 @@
+module UI
+  module Pages
+    class TeaserBox < SitePrism::Section
+      element :title, '.teaser-box__title'
+      element :image, '.teaser-box__image'
+      element :content, '.teaser-box__content'
+      element :link, '.teaser-box__cta'
+    end
+
+    class ForumBox < SitePrism::Section
+      element :title, 'h2'
+      element :content, 'p'
+      elements :links, 'a'
+    end
+
+    class Countries < SitePrism::Section
+      element :title, 'h2'
+      element :content, 'p'
+      elements :links, 'a'
+    end
+
+    class RegionalStrategy < ::UI::Pages::Article
+      set_url '/en/regional_strategies/{/slug}'
+
+      element :main_description, '.hero'
+      element :latest_news, '.latest-news'
+      sections :teaser_boxes, TeaserBox, '.teaser-box'
+      section :supplementary_info_box,
+               ForumBox, '.sidepanel .l-2col-even'
+      sections :countries, Countries, '.list--countries--item'
+    end
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -11,6 +11,7 @@ module World
       lifestage
       latest_news
       news
+      regional_strategy
       thematic_review
       thematic_reviews_landing
     ]

--- a/spec/cassettes/fincap_cms/get/api/en/regional_strategies/wales_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/regional_strategies/wales_json.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/regional_strategies/wales.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.14.0 (Margo-Urey-00241.local; margourey; 47605) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Sat, 14 Jul 2018 20:57:01 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"48277abc65c7b55297f7db37bfc7300d"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 1b19cde3-d8c9-4081-9119-8e7dc1c8167f
+      x-runtime:
+      - '0.257558'
+    body:
+      encoding: UTF-8
+      string: '{"label":"Wales","slug":"wales","full_path":"/en/regional_strategies/wales","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"regional_strategy","related_content":{"latest_blog_post_links":[{"title":"What
+        is a Ponzi scheme and is it a scam?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-a-ponzi-scheme-and-is-it-a-scam"},{"title":"What
+        is the average cost of utility bills per month?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-of-utility-bills-per-month"},{"title":"How
+        much is the average water bill per month?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-is-the-average-water-bill-per-month"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        usually resident population of Wales was 3.1 million people living in 1.3
+        million households\nin 2011, with nearly one in five of residents aged 65
+        or over. Wales had a higher percentage of\nresidents with a long-term health
+        problem or disability. One in four of those aged 16 and over\nreported having
+        no recognised qualification. There are 700,000 people in poverty in Wales,\nequivalent
+        to 23 per cent of the population.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eThe
+        Welsh Government has long recognised that financial exclusion and over-indebtedness
+        are issues that need concerted action\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_title","content":"\u003cp\u003eWales
+        Financial Capability Strategy\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_text","content":"\u003cp\u003eThere
+        is general agreement that there should be one Strategy for Wales.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eLink to strategy\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"forum_title","content":"\u003cp\u003eForum\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"forum_links","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eWelsh Forum\u003c/a\u003e\n        \u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eMoney Advice Service Wales
+        Forum\u003c/a\u003e\n        \u003ca href=\"/financial+capability+strategy.pdf\"\u003eDevelopment
+        Group\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser_section_title","content":"\u003cp\u003eFinancial
+        capability in action\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eChild
+        Poverty Strategy\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eNew
+        objectives for improving the outcomes of children and young people living
+        in low income households.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eStrategy
+        for Older People\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eDelivery
+        Action Plan for Living Longer, Living Better focuses on the three priorities
+        for the Strategy for Older People.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eWarm
+        Homes programme\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eThe
+        government has made considerable investment to address home energy efficiency
+        in low income communities and households.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eYoung Adults download\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"}],"translations":[]}'
+    http_version: 
+  recorded_at: Sat, 14 Jul 2018 20:57:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/regional_strategies/wales_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/regional_strategies/wales_json.yml
@@ -10,7 +10,7 @@ http_interactions:
       Authorization:
       - Token token="mytoken"
       User-Agent:
-      - Mas-Cms-Client/1.14.0 (Margo-Urey-00241.local; margourey; 47605) ruby/2.4.2
+      - Mas-Cms-Client/1.15.0 (Margo-Urey-00241.local; margourey; 55779) ruby/2.4.2
         (198; x86_64-darwin16)
   response:
     status:
@@ -18,7 +18,7 @@ http_interactions:
       message: 
     headers:
       date:
-      - Sat, 14 Jul 2018 20:57:01 GMT
+      - Fri, 20 Jul 2018 10:45:58 GMT
       status:
       - 200 OK
       connection:
@@ -32,48 +32,48 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - '"48277abc65c7b55297f7db37bfc7300d"'
+      - '"bdd4704c07332786db63e19a31d4ef60"'
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 1b19cde3-d8c9-4081-9119-8e7dc1c8167f
+      - 7d456b13-dd67-46f8-bcff-7cbd307219a7
       x-runtime:
-      - '0.257558'
+      - '0.190517'
     body:
       encoding: UTF-8
       string: '{"label":"Wales","slug":"wales","full_path":"/en/regional_strategies/wales","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"regional_strategy","related_content":{"latest_blog_post_links":[{"title":"What
+        is the average cost to have a baby?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-to-have-a-baby"},{"title":"What
         is a Ponzi scheme and is it a scam?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-a-ponzi-scheme-and-is-it-a-scam"},{"title":"What
-        is the average cost of utility bills per month?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-of-utility-bills-per-month"},{"title":"How
-        much is the average water bill per month?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-is-the-average-water-bill-per-month"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        is the average cost of utility bills per month?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-of-utility-bills-per-month"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
         usually resident population of Wales was 3.1 million people living in 1.3
         million households\nin 2011, with nearly one in five of residents aged 65
         or over. Wales had a higher percentage of\nresidents with a long-term health
         problem or disability. One in four of those aged 16 and over\nreported having
         no recognised qualification. There are 700,000 people in poverty in Wales,\nequivalent
-        to 23 per cent of the population.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eThe
+        to 23 per cent of the population.\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eThe
         Welsh Government has long recognised that financial exclusion and over-indebtedness
-        are issues that need concerted action\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_title","content":"\u003cp\u003eWales
-        Financial Capability Strategy\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_text","content":"\u003cp\u003eThere
-        is general agreement that there should be one Strategy for Wales.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"strategy_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eLink to strategy\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"forum_title","content":"\u003cp\u003eForum\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"forum_links","content":"\u003cp\u003e\u003ca
+        are issues that need concerted action\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser_section_title","content":"\u003cp\u003eFinancial
+        capability in action\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eChild
+        Poverty Strategy\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eNew
+        objectives for improving the outcomes of children and young people living
+        in low income households.\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eStrategy
+        for Older People\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eDelivery
+        Action Plan for Living Longer, Living Better focuses on the three priorities
+        for the Strategy for Older People.\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eWarm
+        Homes programme\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eThe
+        government has made considerable investment to address home energy efficiency
+        in low income communities and households.\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eYoung Adults download\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"strategy_title","content":"\u003cp\u003eWales
+        Financial Capability Strategy\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"strategy_text","content":"\u003cp\u003eThere
+        is general agreement that there should be one Strategy for Wales.\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"strategy_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eLink to strategy\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"forum_title","content":"\u003cp\u003eForum\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"},{"identifier":"forum_links","content":"\u003cp\u003e\u003ca
         href=\"/financial+capability+strategy.pdf\"\u003eWelsh Forum\u003c/a\u003e\n        \u003ca
         href=\"/financial+capability+strategy.pdf\"\u003eMoney Advice Service Wales
         Forum\u003c/a\u003e\n        \u003ca href=\"/financial+capability+strategy.pdf\"\u003eDevelopment
-        Group\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser_section_title","content":"\u003cp\u003eFinancial
-        capability in action\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eChild
-        Poverty Strategy\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eNew
-        objectives for improving the outcomes of children and young people living
-        in low income households.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eStrategy
-        for Older People\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eDelivery
-        Action Plan for Living Longer, Living Better focuses on the three priorities
-        for the Strategy for Older People.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eWarm
-        Homes programme\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eThe
-        government has made considerable investment to address home energy efficiency
-        in low income communities and households.\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eYoung Adults download\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-14T17:24:33.000Z","updated_at":"2018-07-14T17:24:33.000Z"}],"translations":[]}'
+        Group\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-18T13:35:12.000Z","updated_at":"2018-07-18T13:35:13.000Z"}],"translations":[]}'
     http_version: 
-  recorded_at: Sat, 14 Jul 2018 20:57:01 GMT
+  recorded_at: Fri, 20 Jul 2018 10:45:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/presenters/article_template_presenter_spec.rb
+++ b/spec/presenters/article_template_presenter_spec.rb
@@ -1,0 +1,196 @@
+RSpec.describe ArticleTemplatePresenter do
+  let(:view) { ActionView::Base.new }
+  let(:object) do
+    double('ArticleTemplate', attributes)
+  end
+  subject(:presenter) { described_class.new(object, view) }
+
+  describe '#strategy_title_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          strategy_title_block: double(
+            content: '<p>Strategy title</p>'
+          )
+        }
+      end
+
+      it 'returns array of hashes containing link attributes' do
+        expect(presenter.strategy_title_component).to eq('Strategy title')
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { strategy_title_block: double(content: '') }
+      end
+
+      it 'returns empty' do
+        expect(presenter.strategy_title_component).to be_empty
+      end
+    end
+  end
+
+  describe '#strategy_link_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          strategy_link_block: double(
+            content: '<p><a href="/strategy.pdf">strategy link content</a></p>'
+          )
+        }
+      end
+
+      it 'returns array of hashes containing link attributes' do
+        expected_result = [
+          { href: '/strategy.pdf', text: 'strategy link content' }
+        ]
+        expect(presenter.strategy_link_component).to eq(expected_result)
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { strategy_link_block: double(content: '') }
+      end
+
+      it 'returns empty' do
+        expect(presenter.strategy_link_component).to be_empty
+      end
+    end
+  end
+  
+  describe '#teaser_section_title_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          teaser_section_title_block: double(content: '<p>Fincap in action</p>')
+        }
+      end
+
+      it 'returns the teaser section title' do
+        expect(presenter.teaser_section_title_component).to eq(
+          'Fincap in action'
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { teaser_section_title_block: nil }
+      end
+
+      it 'returns empty' do
+        expect(presenter.teaser_section_title_component).to be_empty
+      end
+    end
+  end
+
+  describe '#teaser_image_component' do
+    context 'when object has teaser image' do
+      let(:attributes) do
+        {
+          teaser5_image_block: teaser5_image_block
+        }
+      end
+
+      let(:teaser5_image_block) do
+        double(:block,
+               identifier: 'teaser5_image_block',
+               content: '<p>/assets/teaser5_image</p>')
+      end
+
+      it 'returns the teaser image content' do
+        expect(object)
+          .to receive(:teaser_image_block)
+          .with(5)
+          .and_return(teaser5_image_block)
+
+        expect(view)
+          .to receive(:strip_tags)
+          .with(teaser5_image_block.content)
+          .and_return('/assets/teaser5_image')
+
+        presenter.teaser_image_component(5)
+      end
+    end
+
+    context 'when object does not have teaser image' do
+      let(:attributes) do
+        { teaser3_image: nil }
+      end
+
+      it 'returns empty' do
+        expect(object)
+          .to receive(:teaser_image_block)
+          .with(3)
+          .and_return('')
+
+        expect(view)
+          .to receive(:strip_tags)
+          .with('')
+          .and_return('')
+
+        presenter.teaser_image_component(3)
+      end
+    end
+  end
+
+  describe '#teaser_text_component' do
+    context 'when object has teaser text' do
+      let(:attributes) do
+        {
+          teaser3_text_block: teaser3_text_block
+        }
+      end
+
+      let(:teaser3_text_block) do
+        double(:block,
+               identifier: 'teaser3_text_block', content: '<p>teaser text</p>')
+      end
+
+      it 'returns the teaser text content' do
+        expect(object)
+          .to receive(:teaser_text_block)
+          .with(3)
+          .and_return(teaser3_text_block)
+
+        expect(view)
+          .to receive(:strip_tags)
+          .with(teaser3_text_block.content)
+          .and_return('teaser text')
+
+        presenter.teaser_text_component(3)
+      end
+    end
+  end
+
+  describe '#teaser_title_component' do
+    context 'when object has teaser title' do
+      let(:attributes) do
+        {
+          teaser3_title_block: teaser3_title_block
+        }
+      end
+
+      let(:teaser3_title_block) do
+        double(:block,
+               identifier: 'teaser3_title_block', content: '<p>title</p>')
+      end
+
+      it 'returns the teaser title content' do
+        expect(object)
+          .to receive(:teaser_title_block)
+          .with(3)
+          .and_return(teaser3_title_block)
+
+        expect(view)
+          .to receive(:strip_tags)
+          .with(teaser3_title_block.content)
+          .and_return('title')
+
+        presenter.teaser_title_component(3)
+      end
+    end
+  end
+end

--- a/spec/presenters/article_template_presenter_spec.rb
+++ b/spec/presenters/article_template_presenter_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ArticleTemplatePresenter do
       end
     end
   end
-  
+
   describe '#teaser_section_title_component' do
     context 'when object has the block' do
       let(:attributes) do

--- a/spec/presenters/regional_strategy_template_presenter_spec.rb
+++ b/spec/presenters/regional_strategy_template_presenter_spec.rb
@@ -1,41 +1,41 @@
-RSpec.describe LifestageTemplatePresenter do
+RSpec.describe RegionalStrategyTemplatePresenter do
   let(:view) { ActionView::Base.new }
   let(:object) do
-    double('LifestageTemplate', attributes)
+    double('RegionalStrategyTemplate', attributes)
   end
   subject(:presenter) { described_class.new(object, view) }
 
-  describe '#steering_group_title_component' do
+  describe '#forum_title_component' do
     context 'when object has the block' do
       let(:attributes) do
         {
-          steering_group_title_block: double(content: '<p>Steering group</p>')
+          forum_title_block: double(content: '<p>Forum</p>')
         }
       end
 
-      it 'returns the steering group title' do
-        expect(presenter.steering_group_title_component).to eq(
-          'Steering group'
+      it 'returns the forum title' do
+        expect(presenter.forum_title_component).to eq(
+          'Forum'
         )
       end
     end
 
     context 'when object does not have the block' do
       let(:attributes) do
-        { steering_group_title_block: nil }
+        { forum_title_block: nil }
       end
 
       it 'returns empty' do
-        expect(presenter.steering_group_title_component).to be_empty
+        expect(presenter.forum_title_component).to be_empty
       end
     end
   end
 
-  describe '#steering_group_links_component' do
+  describe '#forum_links_component' do
     context 'when object has the block' do
       let(:attributes) do
         {
-          steering_group_links_block: double(
+          forum_links_block: double(
             content: '<p><a href="href1">text1</a><a href="href2">text2</a><p>'
           )
         }
@@ -47,7 +47,7 @@ RSpec.describe LifestageTemplatePresenter do
           { href: 'href2', text: 'text2' }
         ]
 
-        expect(presenter.steering_group_links_component).to eq(
+        expect(presenter.forum_links_component).to eq(
           expected_result
         )
       end
@@ -55,37 +55,37 @@ RSpec.describe LifestageTemplatePresenter do
 
     context 'when object does not have the block' do
       let(:attributes) do
-        { steering_group_links_block: double(content: '') }
+        { forum_links_block: double(content: '') }
       end
 
       it 'returns empty' do
-        expect(presenter.steering_group_links_component).to be_empty
+        expect(presenter.forum_links_component).to be_empty
       end
     end
   end
 
-  describe '#strategy_overview_component' do
+  describe '#strategy_text_component' do
     context 'when object has the block' do
       let(:attributes) do
         {
-          strategy_overview_block: double(content: '<p>Strategy overview</p>')
+          strategy_text_block: double(content: '<p>Strategy text</p>')
         }
       end
 
-      it 'returns the strategy overview content' do
-        expect(presenter.strategy_overview_component).to eq(
-          'Strategy overview'
+      it 'returns the strategy text content' do
+        expect(presenter.strategy_text_component).to eq(
+          'Strategy text'
         )
       end
     end
 
     context 'when object does not have the block' do
       let(:attributes) do
-        { strategy_overview_block: nil }
+        { strategy_text_block: nil }
       end
 
       it 'returns empty' do
-        expect(presenter.strategy_overview_component).to be_empty
+        expect(presenter.strategy_text_component).to be_empty
       end
     end
   end

--- a/spec/templates/article_template_spec.rb
+++ b/spec/templates/article_template_spec.rb
@@ -241,6 +241,4 @@ RSpec.describe ArticleTemplate do
       end
     end
   end
-
 end
-

--- a/spec/templates/article_template_spec.rb
+++ b/spec/templates/article_template_spec.rb
@@ -1,0 +1,246 @@
+RSpec.describe ArticleTemplate do
+  subject { described_class.new(article) }
+  let(:article) do
+    double('Mas::Cms::Article', attributes)
+  end
+
+  describe '.strategy_title_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'strategy_title',
+              content: 'strategy extract'
+            )
+          ]
+        }
+      end
+
+      it 'returns strategy title block' do
+        expect(subject.strategy_title_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'strategy_title',
+            content: 'strategy extract'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.strategy_title_block).to be_nil
+      end
+    end
+  end
+
+  describe '.strategy_link_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'strategy_link',
+              content: 'some link'
+            )
+          ]
+        }
+      end
+
+      it 'returns strategy link block' do
+        expect(subject.strategy_link_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'strategy_link',
+            content: 'some link'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.strategy_link_block).to be_nil
+      end
+    end
+  end
+
+  describe '.teaser_section_title_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'teaser_section_title',
+              content: 'teaser section title'
+            )
+          ]
+        }
+      end
+
+      it 'returns teaser section title block' do
+        expect(subject.teaser_section_title_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'teaser_section_title',
+            content: 'teaser section title'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.teaser_section_title_block).to be_nil
+      end
+    end
+  end
+
+  describe '.teaser_image_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'teaser3_image',
+              content: 'teaser image source'
+            )
+          ]
+        }
+      end
+
+      it 'returns the numbered teaser image block for a given number' do
+        expect(subject.teaser_image_block(3)).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'teaser3_image',
+            content: 'teaser image source'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.teaser_image_block(3)).to be_nil
+      end
+    end
+  end
+
+  describe '.teaser_link_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'teaser2_link',
+              content: 'teaser link'
+            )
+          ]
+        }
+      end
+
+      it 'returns the numbered teaser link block for a given number' do
+        expect(subject.teaser_link_block(2)).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'teaser2_link',
+            content: 'teaser link'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.teaser_link_block(2)).to be_nil
+      end
+    end
+  end
+
+  describe '.teaser_text_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'teaser1_text',
+              content: 'teaser text'
+            )
+          ]
+        }
+      end
+
+      it 'returns the numbered teaser text block for a given number' do
+        expect(subject.teaser_text_block(1)).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'teaser1_text',
+            content: 'teaser text'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.teaser_text_block(1)).to be_nil
+      end
+    end
+  end
+
+  describe '.teaser_title_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'teaser4_title',
+              content: 'teaser title'
+            )
+          ]
+        }
+      end
+
+      it 'returns the numbered teaser title block for a given number' do
+        expect(subject.teaser_title_block(4)).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'teaser4_title',
+            content: 'teaser title'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.teaser_title_block(4)).to be_nil
+      end
+    end
+  end
+
+end
+

--- a/spec/templates/regional_strategy_template_spec.rb
+++ b/spec/templates/regional_strategy_template_spec.rb
@@ -1,27 +1,27 @@
-RSpec.describe LifestageTemplate do
+RSpec.describe RegionalStrategyTemplate do
   subject { described_class.new(article) }
   let(:article) do
     double('Mas::Cms::Article', attributes)
   end
 
-  describe '.steering_group_title_block' do
+  describe '.forum_title_block' do
     context 'when block is present' do
       let(:attributes) do
         {
           non_content_blocks: [
             Mas::Cms::Block.new(
-              identifier: 'steering_group_title',
-              content: 'Steering Groups'
+              identifier: 'forum_title',
+              content: 'Forum'
             )
           ]
         }
       end
 
-      it 'returns steering_group_title block' do
-        expect(subject.steering_group_title_block).to eq(
+      it 'returns forum_title block' do
+        expect(subject.forum_title_block).to eq(
           Mas::Cms::Block.new(
-            identifier: 'steering_group_title',
-            content: 'Steering Groups'
+            identifier: 'forum_title',
+            content: 'Forum'
           )
         )
       end
@@ -33,28 +33,28 @@ RSpec.describe LifestageTemplate do
       end
 
       it 'returns nil' do
-        expect(subject.steering_group_title_block).to be_nil
+        expect(subject.forum_title_block).to be_nil
       end
     end
   end
 
-  describe '.steering_group_links_block' do
+  describe '.forum_links_block' do
     context 'when block is present' do
       let(:attributes) do
         {
           non_content_blocks: [
             Mas::Cms::Block.new(
-              identifier: 'steering_group_links',
+              identifier: 'forum_links',
               content: 'bunch of links'
             )
           ]
         }
       end
 
-      it 'returns steering_group_links block' do
-        expect(subject.steering_group_links_block).to eq(
+      it 'returns forum_links block' do
+        expect(subject.forum_links_block).to eq(
           Mas::Cms::Block.new(
-            identifier: 'steering_group_links',
+            identifier: 'forum_links',
             content: 'bunch of links'
           )
         )
@@ -67,29 +67,29 @@ RSpec.describe LifestageTemplate do
       end
 
       it 'returns nil' do
-        expect(subject.steering_group_links_block).to be_nil
+        expect(subject.forum_links_block).to be_nil
       end
     end
   end
 
-  describe '.strategy_overview_block' do
+  describe '.strategy_text_block' do
     context 'when block is present' do
       let(:attributes) do
         {
           non_content_blocks: [
             Mas::Cms::Block.new(
-              identifier: 'strategy_overview',
-              content: 'some content'
+              identifier: 'strategy_text',
+              content: 'some text'
             )
           ]
         }
       end
 
-      it 'returns strategy overview block' do
-        expect(subject.strategy_overview_block).to eq(
+      it 'returns strategy text block' do
+        expect(subject.strategy_text_block).to eq(
           Mas::Cms::Block.new(
-            identifier: 'strategy_overview',
-            content: 'some content'
+            identifier: 'strategy_text',
+            content: 'some text'
           )
         )
       end
@@ -101,7 +101,7 @@ RSpec.describe LifestageTemplate do
       end
 
       it 'returns nil' do
-        expect(subject.strategy_overview_block).to be_nil
+        expect(subject.strategy_text_block).to be_nil
       end
     end
   end


### PR DESCRIPTION
[TP 9244](https://moneyadviceservice.tpondemand.com/restui/board.aspx#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=userstory/9244)

### REQUIREMENTS
There will be 3 regional strategy pages which show:
- the content for the region
- the latest news component
- ther Research & Evaluation boxes
- strategy and forum content
- CTA links

### MERGE REQUIREMENTS
-  [x] CMS pr #463

### Notes for Reviewing

Whilst this pr looks big (sorry!), reviewing will not be as onerous as one might initially think. 
- The markup and css changes have been previously reviewed as part of pr #164  
- Many of the changes are actually extracting the template and template presenter methods to reduce duplication
- The same is true for the site prism page elements and step definitions to make use of shared steps.
- Shared markup is extracted to partials.

### Technical
- This work makes use of 1 associated task:
  - [adds the facility for editors to input content for a regional strategy page](https://github.com/moneyadviceservice/cms/pull/463)

- This pr continues to make use of the template and presenter framework put in place at the beginning of the project by adding methods specific for the view to the corresponding presenter.