### PR TITLE
9261 Create homepage view

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,3 +1,0 @@
-class HomepageController < ApplicationController
-  def index; end
-end

--- a/app/controllers/homepages_controller.rb
+++ b/app/controllers/homepages_controller.rb
@@ -1,0 +1,16 @@
+class HomepagesController < FincapTemplatesController
+  HOMEPAGE_SLUG = 'root'.freeze
+
+  def show
+    @homepage = Mas::Cms::Homepage.find(HOMEPAGE_SLUG)
+
+    @latest_news = TaggedNews.all(@homepage).map do |news|
+      NewsTemplate.new(news)
+    end
+  end
+
+  def resource
+    HomepageTemplate.new(@homepage)
+  end
+  helper_method :resource
+end

--- a/app/presenters/homepage_template_presenter.rb
+++ b/app/presenters/homepage_template_presenter.rb
@@ -1,0 +1,17 @@
+class HomepageTemplatePresenter < ArticleTemplatePresenter
+  def horizontal_teaser_image_component
+    view.strip_tags(horizontal_teaser_image_block.try(:content).to_s)
+  end
+
+  def horizontal_teaser_link_component
+    extract_links(horizontal_teaser_link_block.try(:content).to_s)
+  end
+
+  def horizontal_teaser_text_component
+    view.strip_tags(horizontal_teaser_text_block.try(:content).to_s)
+  end
+
+  def horizontal_teaser_title_component
+    view.strip_tags(horizontal_teaser_title_block.try(:content).to_s)
+  end
+end

--- a/app/templates/homepage_template.rb
+++ b/app/templates/homepage_template.rb
@@ -1,0 +1,22 @@
+class HomepageTemplate < ArticleTemplate
+  HORIZONTAL_TEASER_IMAGE_ID = 'horizontal_teaser_image'.freeze
+  HORIZONTAL_TEASER_LINK_ID = 'horizontal_teaser_link'.freeze
+  HORIZONTAL_TEASER_TEXT_ID = 'horizontal_teaser_text'.freeze
+  HORIZONTAL_TEASER_TITLE_ID = 'horizontal_teaser_title'.freeze
+
+  def horizontal_teaser_image_block
+    find_block(HORIZONTAL_TEASER_IMAGE_ID)
+  end
+
+  def horizontal_teaser_link_block
+    find_block(HORIZONTAL_TEASER_LINK_ID)
+  end
+
+  def horizontal_teaser_text_block
+    find_block(HORIZONTAL_TEASER_TEXT_ID)
+  end
+
+  def horizontal_teaser_title_block
+    find_block(HORIZONTAL_TEASER_TITLE_ID)
+  end
+end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,1 +1,0 @@
-Financial Capability by Venetia Casely

--- a/app/views/homepages/_horizontal_teaser.html.erb
+++ b/app/views/homepages/_horizontal_teaser.html.erb
@@ -1,0 +1,15 @@
+<div class="teaser-box--horizontal">
+  <img src="<%= template.horizontal_teaser_image_component %>" class="teaser-box__image" />
+  <div class="teaser-box__content">
+    <h3 class="teaser-box__title"><%= template.horizontal_teaser_title_component %></h3>
+    <p class="teaser-box__content-text">
+      <%= template.horizontal_teaser_text_component %>
+    </p>
+    <% template.horizontal_teaser_link_component.each do |link|  %>
+      <%= link_to link[:text], 
+          link[:href], 
+          class: "teaser-box__cta btn btn--primary"
+      %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/homepages/show.html.erb
+++ b/app/views/homepages/show.html.erb
@@ -1,0 +1,55 @@
+<% present(resource) do |template| %>
+  <div class="l-constrained">
+    <%= render "/components/hero",
+      img_src: template.hero_image_component,
+      description: template.hero_description_component
+    %>
+  </div>
+  <div class="l-constrained">
+    <div class="l-2col">
+      <div class="l-2col-side">
+        <h1><%= template.title %></h1>
+        <%= template.body.html_safe %>
+      </div>
+      <div class="l-2col-main">
+        <%= render 'homepages/horizontal_teaser', template: template %>
+      </div>
+    </div>
+  </div>
+  <div class="l-constrained">
+    <div class="row">
+      <div class="teaser-box__group">
+        <h2 class="teaser-box__group-title">
+          <%= template.teaser_section_title_component %>
+        </h2>
+        <div class="teaser-box__group-content">
+          <% (1..3).each do |n| %>
+            <%= render "lifestages/teaser_box",
+              image: template.teaser_image_component(n),
+              title: template.teaser_title_component(n),
+              text: template.teaser_text_component(n)
+            %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="l-3col-even">
+        <%= render 'shared/country_list' %>
+      </div>
+      <div class="l-3col-even">
+        <%= render 'shared/life_stages' %>
+      </div>
+      <div class="l-3col-even">
+        <%= render 'shared/latest_news', latest_news: @latest_news %>
+      </div>
+    </div>
+
+    <div class= "row l-2col">
+      <div class="l-2col-main">
+        <%= template.download_component %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/mas_cms_client.rb
+++ b/config/initializers/mas_cms_client.rb
@@ -14,6 +14,9 @@ end
 class Mas::Cms::Insight < Mas::Cms::Document
 end
 
+class Mas::Cms::Homepage < Mas::Cms::Article
+end
+
 class Mas::Cms::Lifestage < Mas::Cms::Article
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root to: 'homepage#index'
+  root to: 'homepages#show', locale: 'en'
 
   scope ':locale', locale: /en/ do
     resources :articles, only: :show

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -1,0 +1,29 @@
+Feature: Homepage
+  As a user,
+  I want to be able to visit the fincap homepage
+  so that I have a good starting point for further information
+
+  Scenario: Visiting an Homepage
+    Given I entered into the Homepage
+    Then I should see the homepage title "Financial Capability"
+    And I should see the hero description "Welcome to the Financial Capability website"
+    And I should see the homepage content
+    """
+    Welcome to the Financial Capability website, which provides the latest updates on the
+    development of the Financial Capability Strategy for the UK, as well as resources and
+    practical tools to help share learning about what works.
+    """
+    And I should see the horizontal teaser box with
+      | title                    | text                      | link value | href                               |
+      | Horizontal teaser title  | Horizontal teaser content | Click here | /financial+capability+strategy.pdf |
+    And I should see the teaser boxes with
+      | title               | text                                 | link |
+      | First teaser title  | A bunch of ipsem lorem               | #    |
+      | Second teaser title | Kitchen sink ipsem lorem text        | #    |
+      | Third teaser title  | I have run out of ipsem lorem ideas. | #    |
+    And I should see the countries box
+    And I should see the lifestages box
+    And I should see the latest news box
+    And I should see the download links
+      | text                          | link                               |
+      | Financial capability document | /financial+capability+strategy.pdf |

--- a/features/step_definitions/homepage_steps.rb
+++ b/features/step_definitions/homepage_steps.rb
@@ -1,0 +1,22 @@
+Given('I entered into the Homepage') do
+  home_page.load
+end
+
+Then('I should see the homepage title {string}') do |title|
+  expect(home_page).to have_content(title)
+end
+
+Then('I should see the homepage content') do |content|
+  expect(home_page.main_content.first).to have_content(content)
+end
+
+Then('I should see the horizontal teaser box with') do |table|
+  horizontal_teaser = home_page.horizontal_teaser
+
+  table.rows.each do |row|
+    expect(row[0]).to eq(horizontal_teaser.title.text)
+    expect(horizontal_teaser.content).to have_content(row[1])
+    expect(row[2]).to eq(horizontal_teaser.link.text)
+    expect(row[3]).to eq(horizontal_teaser.link[:href])
+  end
+end

--- a/features/support/ui/pages/home.rb
+++ b/features/support/ui/pages/home.rb
@@ -1,0 +1,16 @@
+module UI
+  module Pages
+    class HorizontalTeaser < SitePrism::Section
+      element :title, '.teaser-box__title'
+      element :content, '.teaser-box__content-text'
+      element :link, '.teaser-box__cta'
+    end
+
+    class Home < UI::Page
+      set_url '/'
+
+      elements :main_content, '.l-2col-side'
+      section :horizontal_teaser, HorizontalTeaser, '.teaser-box--horizontal'
+    end
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -8,6 +8,7 @@ module World
       article
       evidence_summaries
       evidence_summary
+      home
       lifestage
       latest_news
       news

--- a/spec/cassettes/fincap_cms/get/api/en/homepages/root_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/homepages/root_json.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/homepages/root.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.15.0 (Margo-Urey-00241.local; margourey; 11256) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Sat, 21 Jul 2018 15:47:03 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"29285464eedb03080c402a744c868d1a"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - ee86cfbc-c208-47db-9ded-3bfa50c3b058
+      x-runtime:
+      - '0.229169'
+    body:
+      encoding: UTF-8
+      string: '{"label":"Financial Capability","slug":"root","full_path":"/en/homepages/root","meta_description":"","meta_title":"","category_names":[],"layout_identifier":"homepage","related_content":{"latest_blog_post_links":[{"title":"What
+        is the average cost to have a baby?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-to-have-a-baby"},{"title":"What
+        is a Ponzi scheme and is it a scam?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-a-ponzi-scheme-and-is-it-a-scam"},{"title":"What
+        is the average cost of utility bills per month?","path":"https://www.moneyadviceservice.org.uk/blog/what-is-the-average-cost-of-utility-bills-per-month"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":"2018-07-21T15:45:43.000Z","supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eWelcome
+        to the Financial Capability website, which provides the latest updates on
+        the development\u003cbr\u003e\nof the Financial Capability Strategy for the
+        UK, as well as resources and practical tools to help\u003cbr\u003e\nshare
+        learning about what works.\u003c/p\u003e\n\n\u003cp\u003eClick \u003ca href=\"https://www.fincap.org.uk/fincapweek\"\u003ehere\u003c/a\u003e
+        for information about Talk Money Week, the annual event which showcases and
+        celebrates\u003cbr\u003e\nhow organisations are improving financial wellbeing
+        and supporting the work of the Financial\u003cbr\u003e\nCapability Strategy.\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T20:14:27.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eWelcome
+        to the Financial Capability website\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eFirst
+        teaser title\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eA
+        bunch of ipsem lorem\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eSecond
+        teaser title\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:04.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eKitchen
+        sink ipsem lorem text\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eThird
+        teaser title\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eI
+        have run out of ipsem lorem ideas.\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"horizontal_teaser_title","content":"\u003cp\u003eHorizontal
+        teaser title\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"horizontal_teaser_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"horizontal_teaser_text","content":"\u003cp\u003eHorizontal
+        teaser content\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T20:46:39.000Z"},{"identifier":"horizontal_teaser_link","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-20T17:30:05.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eFinancial capability document\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-07-20T17:27:16.000Z","updated_at":"2018-07-21T15:45:43.000Z"},{"identifier":"component_teaser_section_title","content":"\n","created_at":"2018-07-20T17:30:05.000Z","updated_at":"2018-07-20T17:30:05.000Z"}],"translations":[]}'
+    http_version: 
+  recorded_at: Sat, 21 Jul 2018 15:47:03 GMT
+recorded_with: VCR 4.0.0

--- a/spec/presenters/homepage_template_presenter_spec.rb
+++ b/spec/presenters/homepage_template_presenter_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe HomepageTemplatePresenter do
+  let(:view) { ActionView::Base.new }
+  let(:object) do
+    double('HomepageTemplate', attributes)
+  end
+  subject(:presenter) { described_class.new(object, view) }
+
+  describe '#horizontal_teaser_image_component' do
+    context 'when object has the corresponding block' do
+      let(:attributes) do
+        {
+          horizontal_teaser_image_block: double(
+            content: '<p>path-to-image.pdf</p>'
+          )
+        }
+      end
+
+      it 'returns the horizontal teaser image content' do
+        expect(presenter.horizontal_teaser_image_component).to eq(
+          'path-to-image.pdf'
+        )
+      end
+    end
+
+    context 'when object does not have teaser image' do
+      let(:attributes) { { horizontal_teaser_image_block: nil } }
+
+      it 'returns empty' do
+        expect(presenter.horizontal_teaser_image_component).to be_empty
+      end
+    end
+  end
+
+  describe '#horizontal_teaser_link_component' do
+    context 'when object has the corresponding block' do
+      let(:attributes) do
+        {
+          horizontal_teaser_link_block: double(
+            content: '<p><a href="path-to-link">cta text</a></p>'
+          )
+        }
+      end
+
+      it 'returns the horizontal teaser link content' do
+        expect(presenter.horizontal_teaser_link_component).to eq(
+          [{ text: 'cta text', href: 'path-to-link' }]
+        )
+      end
+    end
+
+    context 'when object does not have teaser link' do
+      let(:attributes) { { horizontal_teaser_link_block: nil } }
+
+      it 'returns empty' do
+        expect(presenter.horizontal_teaser_link_component).to be_empty
+      end
+    end
+  end
+
+  describe '#horizontal_teaser_text_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          horizontal_teaser_text_block: double(
+            content: '<p>Horizontal teaser text</p>'
+          )
+        }
+      end
+
+      it 'returns the horizontal teaser text' do
+        expect(presenter.horizontal_teaser_text_component).to eq(
+          'Horizontal teaser text'
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { horizontal_teaser_text_block: nil }
+      end
+
+      it 'returns empty' do
+        expect(presenter.horizontal_teaser_text_component).to be_empty
+      end
+    end
+  end
+
+  describe '#horizontal_teaser_title_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          horizontal_teaser_title_block: double(
+            content: '<p>Horizontal teaser title</p>'
+          )
+        }
+      end
+
+      it 'returns the horizontal teaser title' do
+        expect(presenter.horizontal_teaser_title_component).to eq(
+          'Horizontal teaser title'
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { horizontal_teaser_title_block: nil }
+      end
+
+      it 'returns empty' do
+        expect(presenter.horizontal_teaser_title_component).to be_empty
+      end
+    end
+  end
+end

--- a/spec/templates/homepage_template_spec.rb
+++ b/spec/templates/homepage_template_spec.rb
@@ -1,0 +1,142 @@
+RSpec.describe HomepageTemplate do
+  subject { described_class.new(article) }
+  let(:article) do
+    double('Mas::Cms::Homepage', attributes)
+  end
+
+  describe '.horizontal_teaser_image_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'horizontal_teaser_image',
+              content: 'path/to/image.pdf'
+            )
+          ]
+        }
+      end
+
+      it 'returns horizontal_teaser_image block' do
+        expect(subject.horizontal_teaser_image_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'horizontal_teaser_image',
+            content: 'path/to/image.pdf'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.horizontal_teaser_image_block).to be_nil
+      end
+    end
+  end
+
+  describe '.horizontal_teaser_link_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'horizontal_teaser_link',
+              content: 'bunch of links'
+            )
+          ]
+        }
+      end
+
+      it 'returns horizontal_teaser_link block' do
+        expect(subject.horizontal_teaser_link_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'horizontal_teaser_link',
+            content: 'bunch of links'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.horizontal_teaser_link_block).to be_nil
+      end
+    end
+  end
+
+  describe '.horizontal_teaser_text_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'horizontal_teaser_text',
+              content: 'Horizontal teaser text'
+            )
+          ]
+        }
+      end
+
+      it 'returns horizontal_teaser_text block' do
+        expect(subject.horizontal_teaser_text_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'horizontal_teaser_text',
+            content: 'Horizontal teaser text'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.horizontal_teaser_text_block).to be_nil
+      end
+    end
+  end
+
+  describe '.horizontal_teaser_title_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'horizontal_teaser_title',
+              content: 'Horizontal teaser title'
+            )
+          ]
+        }
+      end
+
+      it 'returns horizontal_teaser_title block' do
+        expect(subject.horizontal_teaser_title_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'horizontal_teaser_title',
+            content: 'Horizontal teaser title'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.horizontal_teaser_title_block).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 9261](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=userstory/9261)
 
### REQUIREMENT
The fincap website needs a homepage.

### MERGE REQUIREMENTS
- [ ] [cms pr#465](https://github.com/moneyadviceservice/cms/pull/465) which creates the homepage layout so editors can enter the content for this page.

### TECHNICAL
- direct the 'root' route to the homepages controller
- add template, presenter and view for the page
- add template and presenter methods for the horizontal teaser component

### NOTES FOR REVIEWING
This pr makes use of the [cms pr](https://github.com/moneyadviceservice/cms/pull/465) which creates the homepage layout so editors can enter the content for this page.
#### ROUTING
There are 2 ways to handle the route for landing pages. 
1. set the slug for the specific page. The implication of this approach is:
   -  the requirement for editors to use that slug/constant when creating or amending the content.
2. the query to the cms uses the `all` method and then the `first` method. Refer to the [thematic_reviews_controller#index](https://github.com/moneyadviceservice/fin_cap/blob/master/app/controllers/thematic_reviews_controller.rb#L5-L14). The implications are:
   - the assumption that the document we want is the first one
   - we need to create an additional route in mas-cms-client to ensure the call is handled by the correct CMS controller. Refer to [the implementation of the thematic_reviews route](https://github.com/moneyadviceservice/cms/pull/453)

Whichever approach is chosen, we need to be consistent. If the first approach is selected, changes will be required to thematic_reviews and news controllers.

#### PAGE COMPONENTS
- The only component required to implement for the homepage is the horizontal teaser component.
- All the other components on this page have already been implemented by other page types.
- From a design/frontend perspective, all of the components  already exist in the styleguide and can be dropped into the page.