### PR TITLE
[DEV APPROVED] - Enable preview for Thematic Review pages

### DIFF
--- a/app/controllers/thematic_reviews_preview_controller.rb
+++ b/app/controllers/thematic_reviews_preview_controller.rb
@@ -1,6 +1,6 @@
 class ThematicReviewsPreviewController < ThematicReviewsController
   def resource
-    ArticleTemplate.new(
+    ThematicReviewTemplate.new(
       Mas::Cms::ArticlePreview.find(params[:id], locale: params[:locale])
     )
   end

--- a/app/views/thematic_reviews/show.html.erb
+++ b/app/views/thematic_reviews/show.html.erb
@@ -16,7 +16,9 @@
         </div>
       </div>
       <div class="l-2col-side">
-        <%= render 'shared/latest_news', latest_news: @latest_news %>
+        <div class="row">
+          <%= render 'shared/latest_news', latest_news: @latest_news %>
+        </div>
         <%= template.cta_links_component %>
         <%= template.download_component %>
         <%= template.feedback_component %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,15 @@
 Rails.application.routes.draw do
   root to: 'homepages#show', locale: 'en'
 
+  CMS_PAGES = %w[
+    articles
+    evaluations
+    insights
+    reviews
+    thematic_reviews
+    thematic_reviews_landing_pages
+  ].freeze
+
   scope ':locale', locale: /en/ do
     resources :articles, only: :show
     resources :evaluations, only: :show
@@ -12,13 +21,13 @@ Rails.application.routes.draw do
     resources :reviews, only: :show
     resources :thematic_reviews, only: %i[index show]
 
-    # rubocop:disable Metrics/LineLength
-    get '/:page_type/:id/preview' => 'documents_preview#show',
-        page_type: /articles|evaluations|insights|reviews|thematic_reviews|thematic_reviews_landing_pages/
-    # rubocop:enable Metrics/LineLength
-
+    # Static pages
     get 'get-involved' => 'static_pages#be_involved'
     get 'impact-principles' => 'static_pages#impact_principles'
+
+    # Preview pages
+    get '/:page_type/:id/preview' => 'documents_preview#show',
+        page_type: Regexp.union(CMS_PAGES)
   end
 
   # Styleguide


### PR DESCRIPTION
[TP 9186](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=userstory/9186)

This pr adds preview capability for editors to preview the content of the following cms pages:
- thematic_reviews and 
- thematic_reviews landing pages

#TECHNICAL
- Add preview routes and preview controllers for above pages
- Refactor: declare cms page types and use a regex to define their preview route
- Amend views