### PR TITLE
[DEV APPROVED] 9409 Adding missing body class

### DIFF
--- a/app/views/fincap_templates/show.html.erb
+++ b/app/views/fincap_templates/show.html.erb
@@ -9,9 +9,11 @@
   <div class="l-constrained">
     <div class="l-2col">
       <div class="l-2col-main">
-        <h2><%= template.title %></h2>
+        <div class="body-content">
+          <h2><%= template.title %></h2>
 
-        <%= template.body.html_safe %>
+          <%= template.body.html_safe %>
+        </div>
       </div>
       <div class="l-2col-side">
         <%= template.cta_links_component %>

--- a/app/views/homepages/show.html.erb
+++ b/app/views/homepages/show.html.erb
@@ -7,9 +7,11 @@
   </div>
   <div class="l-constrained">
     <div class="l-2col">
-      <div class="l-2col-side">
-        <h1><%= template.title %></h1>
-        <%= template.body.html_safe %>
+      <div class="l-2col-side">        
+        <div class="body-content">
+          <h1><%= template.title %></h1>
+          <%= template.body.html_safe %>
+        </div>
       </div>
       <div class="l-2col-main">
         <%= render 'homepages/horizontal_teaser', template: template %>

--- a/app/views/lifestages/show.html.erb
+++ b/app/views/lifestages/show.html.erb
@@ -8,8 +8,10 @@
   <div class="l-constrained">
     <div class="l-2col">
       <div class="l-2col-main">
-        <h1><%= template.title %></h1>
-        <%= template.body.html_safe %>
+        <div class="body-content">
+          <h1><%= template.title %></h1>
+          <%= template.body.html_safe %>
+        </div>
       </div>
       <div class="l-2col-side">
         <%= render "shared/latest_news", latest_news: @latest_news %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -8,10 +8,12 @@
 
   <div class="l-constrained">
     <div class="l-2col">
-      <div class="l-2col-main">
-        <h2><%= template.title %></h2>
-        <p class="news-date"><%= template.order_by_date_component %></p>
-        <%= template.body.html_safe %>
+      <div class="l-2col-main">        
+        <div class="body-content">
+          <h2><%= template.title %></h2>
+          <p class="news-date"><%= template.order_by_date_component %></p>
+          <%= template.body.html_safe %>
+        </div>
       </div>
       <div class="l-2col-side">
         <ul class="list list--links">


### PR DESCRIPTION
[TP9409](https://moneyadviceservice.tpondemand.com/entity/9409-add-body-content-class-to-content)

The body class body-content was created to add some padding to the body content and to put back in bullets so that they were visible when used in the wysiwyg in the CMS. 
This PR adds this class to articles, news, lifestages, and the homepage, as they were missing from the markup

### Scrrenshots
**Before**:
<img width="845" alt="screen shot 2018-08-13 at 15 56 22" src="https://user-images.githubusercontent.com/3898629/44039688-81634478-9f11-11e8-9f43-71323f68f944.png">

**After**:
<img width="901" alt="screen shot 2018-08-13 at 15 56 02" src="https://user-images.githubusercontent.com/3898629/44039709-87dbe2b0-9f11-11e8-8327-405c7e291e13.png">
