### PR TITLE
[DEV APPROVED] - 9246 UK strategy page view

### DIFF
--- a/app/controllers/uk_strategies_controller.rb
+++ b/app/controllers/uk_strategies_controller.rb
@@ -1,0 +1,14 @@
+class UkStrategiesController < FincapTemplatesController
+  def show
+    @uk_strategy = Mas::Cms::UkStrategy.find(params[:id])
+
+    @latest_news = TaggedNews.all(@uk_strategy).map do |news|
+      NewsTemplate.new(news)
+    end
+  end
+
+  def resource
+    UkStrategyTemplate.new(@uk_strategy)
+  end
+  helper_method :resource
+end

--- a/app/presenters/uk_strategy_template_presenter.rb
+++ b/app/presenters/uk_strategy_template_presenter.rb
@@ -1,0 +1,15 @@
+class UkStrategyTemplatePresenter < ArticleTemplatePresenter
+  def regional_strategy_title_component
+    view.strip_tags(regional_strategy_title_block.try(:content).to_s)
+  end
+
+  def regional_strategy_link_component
+    extract_links(regional_strategy_link_block.try(:content).to_s)
+      .first
+      .try(:values)
+  end
+
+  def regional_strategy_text_component
+    view.strip_tags(regional_strategy_text_block.try(:content).to_s)
+  end
+end

--- a/app/templates/uk_strategy_template.rb
+++ b/app/templates/uk_strategy_template.rb
@@ -1,0 +1,17 @@
+class UkStrategyTemplate < ArticleTemplate
+  REGIONAL_STRATEGY_TEXT_ID = 'regional_strategy_text'.freeze
+  REGIONAL_STRATEGY_TITLE_ID = 'regional_strategy_title'.freeze
+  REGIONAL_STRATEGY_LINK_ID = 'regional_strategy_link'.freeze
+
+  def regional_strategy_title_block
+    find_block(REGIONAL_STRATEGY_TITLE_ID)
+  end
+
+  def regional_strategy_link_block
+    find_block(REGIONAL_STRATEGY_LINK_ID)
+  end
+
+  def regional_strategy_text_block
+    find_block(REGIONAL_STRATEGY_TEXT_ID)
+  end
+end

--- a/app/views/uk_strategies/show.html.erb
+++ b/app/views/uk_strategies/show.html.erb
@@ -1,0 +1,56 @@
+<% present(resource) do |template| %>
+  <div class="l-constrained">
+    <%= render "/components/hero",
+      img_src: template.hero_image_component,
+      description: template.hero_description_component,
+      hero_colour: "hero--yellow"
+    %>
+  </div>
+  <div class="l-constrained">
+    <div class="l-2col">
+      <div class="l-2col-main">
+        <div class="body-content">
+          <h1><%= template.title %></h1>
+          <%= template.body.html_safe %>
+        </div>
+        <%= render 'shared/research_and_evaluation' %>
+
+        <div class="row">
+          <div class="l-2col l-2col-no-margin">
+            <div class="l-2col-even coloured-box">
+              <h2 class="coloured-box__title"><%= template.regional_strategy_title_component %></h2>
+              <p><%= template.regional_strategy_text_component %></p>
+              <%= link_to *template.regional_strategy_link_component, class: 'btn btn--primary' %>
+            </div>
+            <div class="l-2col-even">
+              <%= render 'shared/life_stages', template: template %>
+            </div>
+          </div>
+        </div>
+
+      </div>
+      <div class="l-2col-side">
+        <%= render "shared/latest_news", latest_news: @latest_news %>
+        <%= render 'shared/country_list' %>
+      </div>
+    </div>
+  </div>
+  <div class="l-constrained">
+    <div class="row">
+      <div class="teaser-box__group">
+        <h2 class="teaser-box__group-title">
+          <%= template.teaser_section_title_component %>
+        </h2>
+        <div class="teaser-box__group-content">
+          <%= render "shared/teaser_group", template: template %>
+        </div>
+      </div>
+    </div>
+
+    <div class= "row l-2col">
+      <div class="l-2col-main">
+        <%= template.download_component %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/initializers/mas_cms_client.rb
+++ b/config/initializers/mas_cms_client.rb
@@ -39,3 +39,6 @@ end
 
 class Mas::Cms::ThematicReviewsLandingPage < Mas::Cms::Article
 end
+
+class Mas::Cms::UkStrategy < Mas::Cms::Article
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
     resources :regional_strategies, only: %i[show]
     resources :reviews, only: :show
     resources :thematic_reviews, only: %i[index show]
+    resources :uk_strategies, only: :show
 
     # Static pages
     get 'get-involved' => 'static_pages#be_involved'

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -22,5 +22,5 @@ Feature: Homepage
       | Second teaser title | Kitchen sink ipsem lorem text        | /financial+capability+strategy.pdf    |
       | Third teaser title  | I have run out of ipsem lorem ideas. | /financial+capability+strategy.pdf    |
     And I should see the countries box
-    And I should see the lifestages box
+    And I should see the life stages box
     And I should see the latest news box

--- a/features/lifestage_page.feature
+++ b/features/lifestage_page.feature
@@ -26,7 +26,7 @@ Feature: Lifestage page
     And I should see the strategy box with
       | title            | text                                         | link                               |
       | Strategy Title   | Adult financial capability is a direct resul | /financial+capability+strategy.pdf | 
-    And I should see the lifestages box
+    And I should see the life stages box
     And I should see the steering group links
       | text                   | link                               |
       | Steering group members | /financial+capability+strategy.pdf |

--- a/features/step_definitions/lifestage_steps.rb
+++ b/features/step_definitions/lifestage_steps.rb
@@ -10,10 +10,6 @@ Then('I should see the lifestage content') do |content|
   expect(lifestage_page.main_content.first).to have_content(content)
 end
 
-Then('I should see the lifestages box') do
-  expect(lifestage_page).to have_content('Life stages across the UK')
-end
-
 Then('I should see the steering group links') do |table|
   links = lifestage_page.supplementary_info_box.last.links
 

--- a/features/step_definitions/regional_strategy_steps.rb
+++ b/features/step_definitions/regional_strategy_steps.rb
@@ -13,12 +13,3 @@ end
 Then('I should see the regional strategy content') do |content|
   expect(regional_strategy_page).to have_content(content)
 end
-
-Then('I should see the latest news box') do
-  expect(regional_strategy_page).to have_latest_news
-end
-
-Then('I should see the countries box') do
-  expect(regional_strategy_page).to have_content('The Strategy across the UK')
-  expect(regional_strategy_page).to have_country_list
-end

--- a/features/step_definitions/shared_page_steps.rb
+++ b/features/step_definitions/shared_page_steps.rb
@@ -34,3 +34,16 @@ Then('I should see the teaser boxes with') do |table|
     expect(row[2]).to be_in(teasers.map { |teaser| teaser.link['href'] })
   end
 end
+
+Then('I should see the life stages box') do
+  expect(current_page).to have_content('Life stages across the UK')
+end
+
+Then('I should see the latest news box') do
+  expect(current_page).to have_latest_news_item
+end
+
+Then('I should see the countries box') do
+  expect(current_page).to have_content('The Strategy across the UK')
+  expect(current_page).to have_country_list
+end

--- a/features/step_definitions/uk_strategy_steps.rb
+++ b/features/step_definitions/uk_strategy_steps.rb
@@ -1,0 +1,15 @@
+Given('I entered into the UK Strategy page {string}') do |title|
+  uk_strategy_page.load(slug: title.parameterize)
+end
+
+Then('I should see the UK Strategy title {string}') do |title|
+  expect(uk_strategy_page).to have_content(title)
+end
+
+Then('I should see the UK Strategy description') do |description|
+  expect(uk_strategy_page).to have_content(description)
+end
+
+Then('I should see the UK Strategy content') do |content|
+  expect(uk_strategy_page).to have_content(content)
+end

--- a/features/support/ui/page.rb
+++ b/features/support/ui/page.rb
@@ -38,5 +38,6 @@ module UI
     sections :lifestage_rows, LifestageRow, '.bordered-box--green li'
     element :title, '.l-2col-main h1'
     element :hero_description, '.hero__heading'
+    element :country_list, 'ul.list--countries'
   end
 end

--- a/features/support/ui/pages/regional_strategy.rb
+++ b/features/support/ui/pages/regional_strategy.rb
@@ -1,17 +1,9 @@
 module UI
   module Pages
-    class Countries < SitePrism::Section
-      element :title, 'h2'
-      element :content, 'p'
-      elements :links, 'a'
-    end
-
     class RegionalStrategy < ::UI::Pages::Article
       set_url '/en/regional_strategies/{/slug}'
 
       element :main_description, '.hero'
-      element :latest_news, '.latest-news'
-      element :country_list, 'ul.list--countries'
     end
   end
 end

--- a/features/support/ui/pages/uk_strategy.rb
+++ b/features/support/ui/pages/uk_strategy.rb
@@ -1,0 +1,7 @@
+module UI
+  module Pages
+    class UkStrategy < ::UI::Pages::Article
+      set_url '/en/uk_strategies/{/slug}'
+    end
+  end
+end

--- a/features/support/world/pages.rb
+++ b/features/support/world/pages.rb
@@ -15,6 +15,7 @@ module World
       regional_strategy
       thematic_review
       thematic_reviews_landing
+      uk_strategy
     ]
 
     pages.each do |page|

--- a/features/uk_strategy_page.feature
+++ b/features/uk_strategy_page.feature
@@ -1,0 +1,31 @@
+Feature: UK Strategy page
+  As a user,
+  I need to be able to visit a landing page relating to the UK only,
+  so that I can get information relating to where I live.
+
+Scenario: Visiting a UK Strategy Page
+  Given I entered into the UK Strategy page "UK Strategy"
+  Then I should see the UK Strategy title "UK Strategy"
+  And I should see the UK Strategy description
+  """
+  Financial capability across the UK
+  """
+  And I should see the UK Strategy content
+  """
+  This Strategy aims to improve financial capability across the UK.
+  That means improving people’s ability to manage money well,
+  both day to day and through significant life events, and their ability
+  to handle periods of financial difficulty. It will focus on developing
+  people’s financial skills and knowledge, and improving their attitudes
+  and motivation. This, combined with an inclusive financial system,
+  can help people achieve the best possible financial wellbeing.
+  """
+  And I should see the latest news box
+  And I should see the countries box
+  And I should see the life stages box
+  And I should see the download links
+    | text                                      | link                               |
+    | UK Strategy                               | /financial+capability+strategy.pdf |
+    | UK Detailed Strategy                      | /detailed-strategy.pdf             |
+    | Key statistics on Financial Capability    | /key-statistics.pdf                |
+    | Financial Capability Progress Report 2017 | /fincap+progress+report+2017.pdf   |

--- a/spec/cassettes/fincap_cms/get/api/en/uk_strategies/uk-strategy_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/uk_strategies/uk-strategy_json.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/uk_strategies/uk-strategy.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (M-C02W80LWGWN.local; giuseppelobraico; 9790) ruby/2.4.2
+        (198; x86_64-darwin17)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Thu, 16 Aug 2018 11:20:40 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"ef952f8b8df93299354f057d6eeb011e"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 0ef6528a-9747-4db0-9e82-c6a96739d5e6
+      x-runtime:
+      - '0.314537'
+    body:
+      encoding: UTF-8
+      string: '{"label":"UK Strategy","slug":"uk-strategy","full_path":"/en/uk_strategies/uk-strategy","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"uk_strategy","related_content":{"latest_blog_post_links":[{"title":"How
+        to spot and avoid PayPal scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-paypal-scams"},{"title":"How
+        to spot and avoid bank scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-bank-scams"},{"title":"How
+        to spot and avoid TV licence refund scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-tv-licence-refund-scams"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eThis
+        Strategy aims to improve financial capability across the UK.\n        That
+        means improving people’s ability to manage money well,\n        both day to
+        day and through significant life events, and their ability\n        to handle
+        periods of financial difficulty. It will focus on developing\n        people’s
+        financial skills and knowledge, and improving their attitudes\n        and
+        motivation. This, combined with an inclusive financial system,\n        can
+        help people achieve the best possible financial wellbeing.\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eFinancial
+        capability across the UK\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser_section_title","content":"\u003cp\u003eFinancial
+        capability across the UK in action\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eExecutive
+        Summary\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eThis
+        is the executive summary content\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
+        href=\"/exectutive+summary.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eThe
+        Strategy\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eThis
+        is the strategy content\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
+        href=\"/the+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eThe
+        Full Strategy\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eThis
+        is the full strategy content\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
+        href=\"/the+full+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"regional_strategy_title","content":"\u003cp\u003eRegional
+        strategy article\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"regional_strategy_text","content":"\u003cp\u003eTo
+        find out more about the regional strategy follow the link below\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"regional_strategy_link","content":"\u003cp\u003e\u003ca
+        href=\"/regional-strategy-link\"\u003eRegional strategy\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
+        href=\"/financial+capability+strategy.pdf\"\u003eUK Strategy\u003c/a\u003e\n      \u003ca
+        href=\"/detailed-strategy.pdf\"\u003eUK Detailed Strategy\u003c/a\u003e\n      \u003ca
+        href=\"/key-statistics.pdf\"\u003eKey statistics on Financial Capability\u003c/a\u003e\n      \u003ca
+        href=\"/fincap+progress+report+2017.pdf\"\u003eFinancial Capability Progress
+        Report 2017\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-16T11:12:36.000Z","updated_at":"2018-08-16T11:12:36.000Z"}],"translations":[]}'
+    http_version: 
+  recorded_at: Thu, 16 Aug 2018 11:20:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/presenters/uk_strategy_template_presenter_spec.rb
+++ b/spec/presenters/uk_strategy_template_presenter_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe UkStrategyTemplatePresenter do
+  subject(:presenter) { described_class.new(object, view) }
+
+  let(:view) { ActionView::Base.new }
+  let(:object) do
+    instance_double(UkStrategyTemplate, attributes)
+  end
+
+  describe '#regional_strategy_title_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          regional_strategy_title_block: double(content: '<p>Title</p>')
+        }
+      end
+
+      it 'returns the regional strategy title' do
+        expect(presenter.regional_strategy_title_component).to eq(
+          'Title'
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { regional_strategy_title_block: nil }
+      end
+
+      it 'returns blank' do
+        expect(presenter.regional_strategy_title_component).to be_blank
+      end
+    end
+  end
+
+  describe '#regional_strategy_link_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          regional_strategy_link_block: double(
+            content: '<p><a href="path">text</a></p>'
+          )
+        }
+      end
+
+      it 'returns an array with the regional strategy text and path' do
+        expect(presenter.regional_strategy_link_component).to eq(
+          %w[text path]
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { regional_strategy_link_block: nil }
+      end
+
+      it 'returns blank' do
+        expect(presenter.regional_strategy_link_component).to be_blank
+      end
+    end
+  end
+
+  describe '#regional_strategy_text_component' do
+    context 'when object has the block' do
+      let(:attributes) do
+        {
+          regional_strategy_text_block: double(content: '<p>Text</p>')
+        }
+      end
+
+      it 'returns the regional strategy text' do
+        expect(presenter.regional_strategy_text_component).to eq(
+          'Text'
+        )
+      end
+    end
+
+    context 'when object does not have the block' do
+      let(:attributes) do
+        { regional_strategy_text_block: nil }
+      end
+
+      it 'returns blank' do
+        expect(presenter.regional_strategy_text_component).to be_blank
+      end
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -18,4 +18,11 @@ VCR.configure do |c|
       )
     end
   end
+
+  # As we deal with API responses in JSON only, we have to enforce UTF-8
+  # in order to avoid the body to be stored as a binary string
+  # More info: https://stackoverflow.com/a/25571825
+  c.before_record do |i|
+    i.response.body.force_encoding('UTF-8')
+  end
 end

--- a/spec/templates/uk_strategy_template_spec.rb
+++ b/spec/templates/uk_strategy_template_spec.rb
@@ -1,0 +1,109 @@
+RSpec.describe UkStrategyTemplate do
+  subject { described_class.new(article) }
+
+  let(:article) do
+    instance_double(Mas::Cms::Article, attributes)
+  end
+
+  describe '#regional_strategy_title_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'regional_strategy_title',
+              content: 'Title'
+            )
+          ]
+        }
+      end
+
+      it 'returns regional_strategy_title block' do
+        expect(subject.regional_strategy_title_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'regional_strategy_title',
+            content: 'Title'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.regional_strategy_title_block).to be_nil
+      end
+    end
+  end
+
+  describe '#regional_strategy_link_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'regional_strategy_link',
+              content: 'Link'
+            )
+          ]
+        }
+      end
+
+      it 'returns regional_strategy_link block' do
+        expect(subject.regional_strategy_link_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'regional_strategy_link',
+            content: 'Link'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.regional_strategy_link_block).to be_nil
+      end
+    end
+  end
+
+  describe '#regional_strategy_text_block' do
+    context 'when block is present' do
+      let(:attributes) do
+        {
+          non_content_blocks: [
+            Mas::Cms::Block.new(
+              identifier: 'regional_strategy_text',
+              content: 'Text'
+            )
+          ]
+        }
+      end
+
+      it 'returns regional_strategy_text block' do
+        expect(subject.regional_strategy_text_block).to eq(
+          Mas::Cms::Block.new(
+            identifier: 'regional_strategy_text',
+            content: 'Text'
+          )
+        )
+      end
+    end
+
+    context 'when block is not present' do
+      let(:attributes) do
+        { non_content_blocks: [] }
+      end
+
+      it 'returns nil' do
+        expect(subject.regional_strategy_text_block).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 9246](https://moneyadviceservice.tpondemand.com/entity/9246-uk-strategy-page-view)

As a user visiting the fincap website, I need to be able to visit a landing page relating to the UK only, so that I can get information relating to where I live. This PR adds the view that presents the information retrieved from the `cms` – depends on [TP 9245](https://moneyadviceservice.tpondemand.com/entity/9245-cms-uk-strategy-page),  https://github.com/moneyadviceservice/cms/pull/478 