### PR TITLE
[DEV APPROVED] 9474 Fix bullets formatting

### DIFF
--- a/app/assets/stylesheets/base/_body.scss
+++ b/app/assets/stylesheets/base/_body.scss
@@ -10,6 +10,10 @@ body {
     list-style-position: inside;
     list-style-type: disc;
 
+    li p {
+      display: inline;
+    }
+
     ul {
       margin-left: $baseline-unit * 3;
     }


### PR DESCRIPTION
[TP 9474](https://moneyadviceservice.tpondemand.com/entity/9474-bullet-points-formatting)

This PR fixes a formatting issue when displaying lists with bullets.

## Technical 

The issue is caused by the fact that the MAS editor _always_ wraps list items with a paragraph _when updating a published page with a list_ – this is a feature that has been like that this since forever.

Although, as a consequence of #175, by adding bullets to list items, we made it obvious to the point that we need to inline paragraphs inside list items.

Originally it was believed to be a backend bug, but it's an actual frontend display issue that can be fixed with some css.