### PR TITLE
[DEV APPROVED] - Add info icon with correct link on the following pages:

### DIFF
--- a/app/views/evidence_summaries/_content.html.erb
+++ b/app/views/evidence_summaries/_content.html.erb
@@ -4,7 +4,6 @@
 
 <p class="evidence-hub__type">
   <%= render 'evidence_type', evidence_summary: evidence_summary %>
-  <a href="http://www.fincap.org.uk/insight_checklist" class="icon--info">i</a>
 </p>
 
 <%= render 'evidence_checklist', evidence_summary: evidence_summary %>

--- a/app/views/shared/_evaluation_types.html.erb
+++ b/app/views/shared/_evaluation_types.html.erb
@@ -5,4 +5,9 @@
      focusable="false">
   <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--<%= "#{type.downcase}" %>-icon"></use>
 </svg>
-<span class="evaluation-type__text evaluation-type__text--<%= "#{type.downcase}" %>"><%= type %></span>
+<span class="evaluation-type__text evaluation-type__text--<%= "#{type.downcase}" %>">
+  <%= type %>
+</span>
+<span>
+  <%= link_to 'i', article_path(locale: "en", id: "evidence-type-#{type.downcase}"), class: "icon--info" %>
+</span>

--- a/features/evaluation_summary_page.feature
+++ b/features/evaluation_summary_page.feature
@@ -19,6 +19,7 @@ Feature: Evidence Hub: Evaluation Summary page
       | Country                | United Kingdom                                        |
       | Contact information    | MASPD (in partnership with Company S.A)               |
       | Links                  | Looking after the pennies - full report               |
+    And I should see an icon linking to "Evaluation" article
     And I should see the evidence summary data_types
       | Field                       | Value |
       | programme_theory            | cross |

--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -15,6 +15,7 @@ Feature: Evidence Hub Search
       | topics              | Saving                                                   |
       | countries           | United Kingdom                                           |
       | year of publication | 2015                                                     |
+    And I should see the "first" evidence summary icon linking to "Insight" article
     And I should see the "first" evidence summary with data types as
       | Field         | Value |
       | qualitative   | tick  |
@@ -27,6 +28,7 @@ Feature: Evidence Hub Search
       | topics              | Credit Use and Debt                                                                |
       | countries           | England                                                                            |
       | year of publication | 2017                                                                               |
+    And I should see the "second" evidence summary icon linking to "Insight" article
     And I should see the "second" evidence summary with data types as
       | Field         | Value |
       | qualitative   | cross |
@@ -43,6 +45,7 @@ Feature: Evidence Hub Search
       | topics              | Saving                                                   |
       | countries           | United Kingdom                                           |
       | year of publication | 2015                                                     |
+    And I should see the "first" evidence summary icon linking to "Insight" article
     And I should see the "first" evidence summary with data types as
       | Field         | Value |
       | qualitative   | tick  |
@@ -60,6 +63,7 @@ Feature: Evidence Hub Search
       | topics              | Saving                                                   |
       | countries           | United Kingdom                                           |
       | year of publication | 2015                                                     |
+    And I should see the "first" evidence summary icon linking to "Insight" article
 
   Scenario: Search by Year of Publication filter
     When I search the evidence hub for summaries published in the last 2 years
@@ -71,6 +75,7 @@ Feature: Evidence Hub Search
       | topics              | Credit Use and Debt                                                |
       | countries           | England                                                            |
       | year of publication | 2017                                                               |
+    And I should see the "first" evidence summary icon linking to "Insight" article
 
   Scenario: Clearing the filters for a filtered search
     Given I search based on some filters
@@ -94,6 +99,7 @@ Feature: Evidence Hub Search
       | evidence type       | Insight                                                  |
       | topics              | Saving                                                   |
       | countries           | United Kingdom                                           |
+    And I should see an icon linking to "Insight" article
 
   Scenario: Going to the next page
     Given I am on the page "1" seeing "1" evidence summary per page
@@ -107,6 +113,7 @@ Feature: Evidence Hub Search
       | topics              | Credit Use and Debt                                                                |
       | countries           | England                                                                            |
       | year of publication | 2017                                                                               |
+    And I should see the "first" evidence summary icon linking to "Insight" article
 
   Scenario: Return to the previous page
     Given I am on the page "2" seeing "1" evidence summary per page
@@ -119,3 +126,4 @@ Feature: Evidence Hub Search
       | evidence type       | Insight                                                  |
       | topics              | Saving                                                   |
       | countries           | United Kingdom                                           |
+    And I should see the "first" evidence summary icon linking to "Insight" article

--- a/features/insight_summary_page.feature
+++ b/features/insight_summary_page.feature
@@ -16,6 +16,7 @@ Feature: Evidence Hub: Insight Summary page
       | Country             | United Kingdom                                           |
       | Contact information | MASPD (in partnership with Company S.A)                  |
       | Links               | Financial well-being: the employee view - full report    |
+    And I should see an icon linking to "Insight" article
     And I should see the evidence summary data_types
       | Field        | Content |
       | qualitative  | tick    |

--- a/features/review_summary_page.feature
+++ b/features/review_summary_page.feature
@@ -19,6 +19,7 @@ Feature: Evidence Hub: Review Summary page
       | Country             | International review                   |
       | Contact information | John Smith                             |
       | Links               | Raising household saving - full report |
+    And I should see an icon linking to "Review" article
     And I should see the evidence summary data_types
       | Field             | Content |
       | systematic_review | tick    |

--- a/features/step_definitions/evidence_hub/search_steps.rb
+++ b/features/step_definitions/evidence_hub/search_steps.rb
@@ -52,6 +52,16 @@ Then('I should see {string} evidence summary') do |records_size|
 end
 
 Then(
+  'I should see the {string} evidence summary icon linking to {string} article'
+) do |result_number, evidence_type|
+  search_result = evidence_summaries_page.search_results.send(result_number)
+  path = "/en/articles/evidence-type-#{evidence_type.downcase}"
+
+  expect(search_result).to have_info_icon
+  expect(search_result.info_icon[:href]).to eq(path)
+end
+
+Then(
   'I should see the {string} evidence summary with data types as'
 ) do |result_number, table|
   search_result = evidence_summaries_page.search_results.send(result_number)

--- a/features/step_definitions/evidence_hub/show_steps.rb
+++ b/features/step_definitions/evidence_hub/show_steps.rb
@@ -24,6 +24,13 @@ Then('I should see the evidence summary content') do |table|
   end
 end
 
+Then('I should see an icon linking to {string} article') do |evidence_type|
+  path = "/en/articles/evidence-type-#{evidence_type.downcase}"
+
+  expect(evidence_summary_page).to have_info_icon
+  expect(evidence_summary_page.info_icon[:href]).to eq(path)
+end
+
 Then('I should see the evidence summary data_types') do |table|
   table.rows.each do |row|
     data_type_element = evidence_summary_page.send(row[0])

--- a/features/support/ui/pages/evidence_summaries.rb
+++ b/features/support/ui/pages/evidence_summaries.rb
@@ -16,6 +16,7 @@ module UI::Pages
       element :causality, '.data-types__causality svg'
       element :process_evaluation, '.data-types__process-evaluation svg'
       element :value_for_money, '.data-types__value-for-money svg'
+      element :info_icon, 'a.icon--info'
     end
 
     set_url '{/locale}/evidence_hub'

--- a/features/support/ui/pages/evidence_summary.rb
+++ b/features/support/ui/pages/evidence_summary.rb
@@ -23,6 +23,7 @@ module UI
       element :value_for_money, '.data-types__value-for-money svg'
       element :systematic_review, '.data-types__systematic-review svg'
       element :literature_review, '.data-types__literature-review svg'
+      element :info_icon, 'a.icon--info'
     end
   end
 end


### PR DESCRIPTION
[TP 9459](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9405&searchPopup=userstory/9459)

### REQUIREMENT
In the Evidence Hub page, the information icon should appear next to each summary. It should also appear on the evidence summary page. In all cases, the icon should link to the article page for the corresponding evidence type e.g. if the evidence summary is a review, the icon should link to the evidence-type-review article.