### PR TITLE
[DEV APPROVED] Add redirect feature to fincap site

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  rescue_from Mas::Cms::HttpRedirect, with: :redirect_page
+
+  private
+
+  def redirect_page(redirect)
+    redirect_to redirect.location, status: redirect.http_response.status
+  end
 end

--- a/app/controllers/catch_all_controller.rb
+++ b/app/controllers/catch_all_controller.rb
@@ -1,0 +1,18 @@
+class CatchAllController < ApplicationController
+  rescue_from Mas::Cms::Errors::ResourceNotFound, with: :not_found
+  rescue_from Mas::Cms::Errors::ClientError, with: :not_found
+
+  def index
+    Mas::Cms::Client.connection.get("/api/#{params[:path]}")
+
+    not_found
+  end
+
+  private
+
+  def not_found
+    raise ActionController::RoutingError.new(
+      "No route matches #{params[:path]}"
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,5 @@ Rails.application.routes.draw do
   # Styleguide
   get '/styleguide', to: 'styleguide#home'
   get 'styleguide/:page' => 'styleguide#show'
+  get '*path', to: 'catch_all#index'
 end

--- a/features/redirect.feature
+++ b/features/redirect.feature
@@ -1,0 +1,24 @@
+ Feature: Redirect
+  As a user,
+  I want to be able to visit an old page
+  so that I have a good starting point for further information
+
+  Scenario: Visiting an old site insight page
+    Given I visit the page '/document/WOuEzCsAAIaQ8tXy/financial-well-being-the-employee-view'
+    Then I should be reading the page '/en/insights/financial-well-being-the-employee-view'
+
+  Scenario: Visiting an old site evaluation page
+    Given I visit the page '/document/WOYJaysAADA42rIr/looking-after-the-pennies'
+    Then I should be reading the page '/en/evaluations/looking-after-the-pennies'
+
+  Scenario: Visiting an old site review page
+    Given I visit the page '/document/WTVdRSkAAOsYaAQx/raising-household-saving'
+    Then I should be reading the page '/en/reviews/raising-household-saving'
+
+  Scenario: Visiting an old site vanity url
+    Given I visit the page '/young-adults'
+    Then I should be reading the page '/en/lifestages/young-adults'
+
+  Scenario: Visiting an old site news page
+    Given I visit the page '/en/news/old-news'
+    Then I should be reading the page '/en/news/press-release-a-new-way-to-pay'

--- a/features/redirect.feature
+++ b/features/redirect.feature
@@ -22,3 +22,8 @@
   Scenario: Visiting an old site news page
     Given I visit the page '/en/news/old-news'
     Then I should be reading the page '/en/news/press-release-a-new-way-to-pay'
+
+  @allow-rescue
+  Scenario: Visiting a page that does not exist and does not have a redirect
+    Given I visit the page '/this-page-dont-exist-anywhere'
+    Then I should see the page not found

--- a/features/step_definitions/shared_page_steps.rb
+++ b/features/step_definitions/shared_page_steps.rb
@@ -6,6 +6,11 @@ Then('I should be reading the page {string}') do |path|
   expect(page.current_path).to eq(path)
 end
 
+Then('I should see the page not found') do
+  expect(current_page).to have_content('Routing Error No route matches')
+  expect(current_page.status_code).to be(404)
+end
+
 Then('I should see the hero description {string}') do |description|
   expect(current_page.hero_description.text).to eq(description)
 end

--- a/features/step_definitions/shared_page_steps.rb
+++ b/features/step_definitions/shared_page_steps.rb
@@ -1,3 +1,11 @@
+Given('I visit the page {string}') do |path|
+  visit(path)
+end
+
+Then('I should be reading the page {string}') do |path|
+  expect(page.current_path).to eq(path)
+end
+
 Then('I should see the hero description {string}') do |description|
   expect(current_page.hero_description.text).to eq(description)
 end

--- a/spec/cassettes/fincap_cms/get/api/document/WOYJaysAADA42rIr/looking-after-the-pennies.yml
+++ b/spec/cassettes/fincap_cms/get/api/document/WOYJaysAADA42rIr/looking-after-the-pennies.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/document/WOYJaysAADA42rIr/looking-after-the-pennies
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 12475) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 301
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:23:08 GMT
+      status:
+      - 301 Moved Permanently
+      connection:
+      - close
+      location:
+      - http://localhost:5000/en/evaluations/looking-after-the-pennies
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 6027900c-5a5d-477f-8688-bbc7e52c808e
+      x-runtime:
+      - '0.066214'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:23:08 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/document/WOuEzCsAAIaQ8tXy/financial-well-being-the-employee-view.yml
+++ b/spec/cassettes/fincap_cms/get/api/document/WOuEzCsAAIaQ8tXy/financial-well-being-the-employee-view.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/document/WOuEzCsAAIaQ8tXy/financial-well-being-the-employee-view
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 12392) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 301
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:22:28 GMT
+      status:
+      - 301 Moved Permanently
+      connection:
+      - close
+      location:
+      - http://localhost:5000/en/insights/financial-well-being-the-employee-view
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 449438b0-9089-4e9d-ad50-934da3a9331d
+      x-runtime:
+      - '0.037286'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:22:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/document/WTVdRSkAAOsYaAQx/raising-household-saving.yml
+++ b/spec/cassettes/fincap_cms/get/api/document/WTVdRSkAAOsYaAQx/raising-household-saving.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/document/WTVdRSkAAOsYaAQx/raising-household-saving
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 12475) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 301
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:23:09 GMT
+      status:
+      - 301 Moved Permanently
+      connection:
+      - close
+      location:
+      - http://localhost:5000/en/reviews/raising-household-saving
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 79273edc-f31a-478c-99c2-3f177cb7e052
+      x-runtime:
+      - '0.039269'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:23:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/news/old-news_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/news/old-news_json.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/news/old-news.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 11553) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 301
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:09:26 GMT
+      status:
+      - 301 Moved Permanently
+      connection:
+      - close
+      location:
+      - http://localhost:5000/en/news/press-release-a-new-way-to-pay
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 97bc70e2-b5eb-4548-ae2a-3f2392cef279
+      x-runtime:
+      - '0.040058'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:09:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/pages/changing-behaviour-around-online-transactions/preview.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/pages/changing-behaviour-around-online-transactions/preview.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/pages/changing-behaviour-around-online-transactions/preview
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 12936) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 400
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:29:20 GMT
+      status:
+      - 400 Bad Request
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 7158ddc9-7587-4e72-a9be-eb2e852020f2
+      x-runtime:
+      - '0.065981'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Page type \"page\" not supported"}'
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:29:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/this-page-dont-exist-anywhere.yml
+++ b/spec/cassettes/fincap_cms/get/api/this-page-dont-exist-anywhere.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/this-page-dont-exist-anywhere
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 18330) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 404
+      message: 
+    headers:
+      date:
+      - Thu, 23 Aug 2018 10:10:17 GMT
+      status:
+      - 404 Not Found
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 517db334-35c2-4e36-8c97-307b9c19c9b5
+      x-runtime:
+      - '0.245517'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Site \"api\" not found"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:10:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/young-adults.yml
+++ b/spec/cassettes/fincap_cms/get/api/young-adults.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/young-adults
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 12475) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 301
+      message: 
+    headers:
+      date:
+      - Wed, 22 Aug 2018 17:23:09 GMT
+      status:
+      - 301 Moved Permanently
+      connection:
+      - close
+      location:
+      - http://localhost:5000/en/lifestages/young-adults
+      cache-control:
+      - no-cache
+      x-request-id:
+      - c66ae519-dd96-4411-86f2-12eedc3f1ddf
+      x-runtime:
+      - '0.039014'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 22 Aug 2018 17:23:09 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9225-implement-internal-redirect-feature-on-fincap)

## Solution

The redirect mechanism is implemented as follows:

- The user visits a page that does not exist:

  Fincap app will request to CMS if the page contains a redirect. If it does, it will redirect the user; if not normal Rails flow will follow.

- The user visits any supported page type but the page does not exist:

  If there is a redirect on CMS, Fincap app will catch the redirect exception from mas-cms-client gem
  and redirect the user to the destination specified on CMS.

In all other cases, the app will continue to run and will return the 'not found' page. 

## Observations

This depends on this PR https://github.com/moneyadviceservice/cms/pull/480
Please review this PR as well.