### PR TITLE
[DEV APPROVED] 9519 Update links in the research and evaluation boxes

### DIFF
--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -1,5 +1,6 @@
 module ComponentsHelper
   UK_REGION = 'uk'.freeze
+  STATIC_PAGE_TYPE = 'static'.freeze
 
   def strategy_path(country)
     if region_uk?(country[:region])
@@ -9,9 +10,23 @@ module ComponentsHelper
     end
   end
 
+  def define_path(page)
+    return send(to_path(page[:slug]), locale: 'en') if static_page?(page)
+
+    article_path(id: page[:slug], locale: 'en')
+  end
+
   private
 
   def region_uk?(region)
     region == UK_REGION
+  end
+
+  def static_page?(page)
+    page[:page_type] == STATIC_PAGE_TYPE
+  end
+
+  def to_path(slug)
+    "#{slug.underscore}_path"
   end
 end

--- a/app/views/shared/_research_and_evaluation.html.erb
+++ b/app/views/shared/_research_and_evaluation.html.erb
@@ -4,9 +4,7 @@
     <ul class="list list--links coloured-box__list">
       <% I18n.t('fincap.research_evaluation.findings').each do |link| %>
         <li>
-          <a href="<%= link[:url] %>">
-            <%= link[:text] %>
-          </a>
+          <%= link_to(link[:text], article_path(locale: 'en', id: link[:slug])) %>
         </li>
       <% end %>
     </ul>
@@ -14,12 +12,8 @@
   <div class="l-2col-even coloured-box">
     <h2 class="coloured-box__title">Evaluate your programme</h2>
     <ul class="list list--links coloured-box__list">
-      <% I18n.t('fincap.research_evaluation.existing').each do |link| %>
-        <li>
-          <a href="<%= link[:url] %>">
-            <%= link[:text] %>
-          </a>
-        </li>
+      <% I18n.t('fincap.research_evaluation.existing').each do |page| %>
+        <li><%= link_to(page[:text], define_path(page)) %></li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,16 +78,21 @@ en:
     research_evaluation:
       findings:
         - text: Existing Research
-          url: 'link-to/financial-capability-survey'
+          slug: find-evidence
+          page_type: article
         - text: Evidence hub
-          url: 'link-to/evidence_hub'
+          slug: financial-capability-evidence-hub
+          page_type: article
       existing:
-        - text: Measure your performance
-          url: 'link-to/evaluate-your-programme'
         - text: Evaluation toolkit
-          url: 'link-to/evaluation-toolkit-homepage'
+          slug: evaluation-toolkit-overview
+          page_type: article
+        - text: IMPACT Principles
+          slug: impact-principles
+          page_type: static
         - text: Outcomes Frameworks and question banks
-          url: 'link-to/outcome-framework'
+          slug: outcomes-frameworks-and-question-banks
+          page_type: article
     countries:
       title: The Strategy across the UK
       intro: As well as the UK Strategy, there are strategies for Northern Ireland, Scotland and Wales.

--- a/features/components/research_and_evaluation.feature
+++ b/features/components/research_and_evaluation.feature
@@ -1,0 +1,19 @@
+Feature: Research and Evaluation
+  As a fincap website user
+  I want to be able to see all Research and Evaluation documents
+  So that I can learn how Financial Capability is researched
+
+  Scenario: Research Findings
+    Given I entered a page which includes the R&E component
+    Then I should see "2" links for "Research and findings"
+      | Name              | Link                                           |
+      | Existing Research | /en/articles/find-evidence                     |
+      | Evidence hub      | /en/articles/financial-capability-evidence-hub |
+
+  Scenario: Existing Evaluation
+    Given I entered a page which includes the R&E component
+    Then I should see "3" links for "Evaluate your programme"
+      | Name                                   | Link                                                |
+      | Evaluation toolkit                     | /en/articles/evaluation-toolkit-overview            |
+      | IMPACT Principles                      | /en/impact-principles                               |
+      | Outcomes Frameworks and question banks | /en/articles/outcomes-frameworks-and-question-banks |

--- a/features/lifestage_page.feature
+++ b/features/lifestage_page.feature
@@ -18,20 +18,20 @@ Feature: Lifestage page
       | title                            | date                  | link                                    |
       | Press Release: A new way to pay! | Thursday 26 July 2018 | /en/news/press-release-a-new-way-to-pay |
     And I should see the teaser boxes with
-      | title                       | text                                              | link |
-      | Some title to tease you     | Loads of content to make you read more            | /financial+capability+strategy.pdf    |
-      | Another title to entice you | A bunch of well written content to make you click | /financial+capability+strategy.pdf    |
-      | Teasing title               | You want to read this, you need to read this      | /financial+capability+strategy.pdf    |
+      | title          | text                                                                                                              | link                    |
+      | Teaser 3 title | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf |
+      | Teaser 3 title | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf |
+      | Teaser 3 title | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf |
     And I should see the research box
     And I should see the strategy box with
       | title            | text                                         | link                               |
-      | Strategy Title   | Adult financial capability is a direct resul | /financial+capability+strategy.pdf | 
+      | Strategy title   | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf | 
     And I should see the life stages box
     And I should see the steering group links
-      | text                   | link                               |
-      | Steering group members | /financial+capability+strategy.pdf |
-      | Steering group updates | /financial+capability+strategy.pdf |
-      | Action plans           | /financial+capability+strategy.pdf |
+      | text                | link                       |
+      | Evidence Hub        | /general_info              |
+      | Evaluation Toolkit  | /common-evaluation-toolkit |
+      | The Steering Groups | /steering-groups           |
     And I should see the download links
-      | text                  | link                               |
-      | Young Adults download | /financial+capability+strategy.pdf |
+      | text         | link          |
+      | Evidence Hub | /general_info |

--- a/features/step_definitions/components/research_evaluation_steps.rb
+++ b/features/step_definitions/components/research_evaluation_steps.rb
@@ -1,0 +1,14 @@
+ Given('I entered a page which includes the R&E component') do
+  step %(I entered into the Lifestage page "Young Adults")
+end
+
+Then('I should see {string} links for {string}') do |number, title, table|
+  items = current_page.find_box(title).research_rows
+
+  expect(items.count).to eq(number.to_i)
+
+  table.rows.each do |row|
+    expect(row[0]).to be_in(items.map(&:text))
+    expect(row[1]).to be_in(items.map { |item| item.link[:href] })
+  end
+end

--- a/features/support/ui/page.rb
+++ b/features/support/ui/page.rb
@@ -32,6 +32,15 @@ module UI
     element :link, 'a'
   end
 
+  class ResearchRow < SitePrism::Section
+    element :link, 'a'
+  end
+
+  class ResearchEvaluationBox < SitePrism::Section
+    sections :research_rows, ResearchRow, 'li'
+    element :title, 'h2'
+  end
+
   class Page < SitePrism::Page
     sections :download_box,
              DownloadBoxSection, '.download-box ul.download-box__list li'
@@ -41,8 +50,15 @@ module UI
              SupplementaryInfoBox, '.sidepanel .l-2col-even'
     sections :lifestage_rows, LifestageRow, '.bordered-box--green li'
     sections :country_rows, CountryRow, '.list--countries-item'
+    sections :research_and_evaluation_boxes, 
+             ResearchEvaluationBox, '.coloured-box'
+
     element :title, '.l-2col-main h1'
     element :hero_description, '.hero__heading'
     element :country_list, 'ul.list--countries'
+
+    def find_box(title)
+      research_and_evaluation_boxes.find { |box| box.title.text == title }
+    end
   end
 end

--- a/spec/cassettes/fincap_cms/get/api/en/lifestages/young-adults_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/lifestages/young-adults_json.yml
@@ -10,7 +10,7 @@ http_interactions:
       Authorization:
       - Token token="mytoken"
       User-Agent:
-      - Mas-Cms-Client/1.17.0 (Margo-Urey-00241.local; margourey; 40273) ruby/2.4.2
+      - Mas-Cms-Client/1.17.0 (Margo-Urey-00241.local; margourey; 52256) ruby/2.4.2
         (198; x86_64-darwin16)
   response:
     status:
@@ -18,7 +18,7 @@ http_interactions:
       message: 
     headers:
       date:
-      - Thu, 16 Aug 2018 20:07:41 GMT
+      - Tue, 28 Aug 2018 09:20:26 GMT
       status:
       - 200 OK
       connection:
@@ -32,42 +32,46 @@ http_interactions:
       content-type:
       - application/json; charset=utf-8
       etag:
-      - '"c8c2b657b122a9cafc3774ad38824e45"'
+      - '"1569e92ce955f7092da5816e9e5534d7"'
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 7c77cdf0-4bd9-4360-be3c-a5be8ce28c61
+      - 61dc4a74-fdfb-41fe-948a-295c88b8afdc
       x-runtime:
-      - '0.105606'
+      - '0.271617'
     body:
       encoding: UTF-8
       string: '{"label":"Young Adults","slug":"young-adults","full_path":"/en/lifestages/young-adults","meta_description":"","meta_title":"","category_names":[],"layout_identifier":"lifestage","related_content":{"latest_blog_post_links":[{"title":"How
-        to spot and avoid PayPal scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-paypal-scams"},{"title":"How
-        to spot and avoid bank scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-bank-scams"},{"title":"How
-        to spot and avoid TV licence refund scams","path":"https://www.moneyadviceservice.org.uk/blog/how-to-spot-and-avoid-tv-licence-refund-scams"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":"2018-08-16T19:02:55.000Z","supports_amp":true,"tags":["mobile-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eYoung
+        to spot and avoid DVLA scams","path":"https://www.moneyadviceservice.org.uk/blog/dvla-scams"},{"title":"What
+        my daughter really needs to know about money and university","path":"https://www.moneyadviceservice.org.uk/blog/money-and-university"},{"title":"What
+        to take to university (and what to leave behind)","path":"https://www.moneyadviceservice.org.uk/blog/what-to-take-to-university-and-what-to-leave-behind"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":"2018-08-28T09:19:47.000Z","supports_amp":true,"tags":["mobile-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eYoung
         adults are those who have left compulsory education or other statutory settings,\u003cbr\u003e\nsuch
         as care. They are transitioning towards independent living and financial\u003cbr\u003e\nindependence,
-        beginning between the ages of 16 to 18 and continuing to their mid-20s.\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eResearch
+        beginning between the ages of 16 to 18 and continuing to their mid-20s.\u003c/p\u003e\n","created_at":"2018-08-20T15:29:29.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eResearch
         suggests that young adults typically display lower levels of financial capability
-        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eSome
-        title to tease you\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eLoads
-        of content to make you read more\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eAnother
-        title to entice you\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eA
-        bunch of well written content to make you click\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eRead more\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eTeasing
-        title\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eYou
-        want to read this, you need to read this\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eClick here\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"strategy_title","content":"\u003cp\u003eStrategy
-        Title\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"strategy_overview","content":"\u003cp\u003eAdult
-        financial capability is a direct resul\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"strategy_link","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eLink to strategy\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"steering_group_title","content":"\u003cp\u003eSteering
-        group\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"steering_group_links","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eSteering group members\u003c/a\u003e        \u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eSteering group updates\u003c/a\u003e        \u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eAction plans\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
-        href=\"/financial+capability+strategy.pdf\"\u003eYoung Adults download\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-03T19:09:31.000Z","updated_at":"2018-08-16T19:02:55.000Z"},{"identifier":"component_teaser_section_title","content":"\u003cp\u003eFinancial
-        capability in action\u003c/p\u003e\n","created_at":"2018-08-16T19:02:55.000Z","updated_at":"2018-08-16T19:02:55.000Z"}],"translations":[]}'
+        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"component_teaser_section_title","content":"\u003cp\u003eFinancial
+        Capability in action\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser1_title","content":"\u003cp\u003eTeaser
+        3 title\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser1_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser1_text","content":"\u003cp\u003eResearch
+        suggests that young adults typically display lower levels of financial capability
+        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser1_link","content":"\u003cp\u003e\u003ca
+        href=\"/exectutive+summary.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser2_title","content":"\u003cp\u003eTeaser
+        3 title\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser2_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser2_text","content":"\u003cp\u003eResearch
+        suggests that young adults typically display lower levels of financial capability
+        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser2_link","content":"\u003cp\u003e\u003ca
+        href=\"/exectutive+summary.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser3_title","content":"\u003cp\u003eTeaser
+        3 title\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser3_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser3_text","content":"\u003cp\u003eResearch
+        suggests that young adults typically display lower levels of financial capability
+        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"teaser3_link","content":"\u003cp\u003e\u003ca
+        href=\"/exectutive+summary.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"strategy_title","content":"\u003cp\u003eStrategy
+        title\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"strategy_overview","content":"\u003cp\u003eResearch
+        suggests that young adults typically display lower levels of financial capability
+        than older age groups.\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"strategy_link","content":"\u003cp\u003e\u003ca
+        href=\"/exectutive+summary.pdf\"\u003eteaser1 link text\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"steering_group_title","content":"\u003cp\u003eSteering
+        group title\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"steering_group_links","content":"\u003cp\u003e\u003ca
+        href=\"/general_info\"\u003eEvidence Hub\u003c/a\u003e        \u003ca href=\"/common-evaluation-toolkit\"\u003eEvaluation
+        Toolkit\u003c/a\u003e        \u003ca href=\"/steering-groups\"\u003eThe Steering
+        Groups\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"},{"identifier":"component_download","content":"\u003cp\u003e\u003ca
+        href=\"/general_info\"\u003eEvidence Hub\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-20T15:32:50.000Z","updated_at":"2018-08-20T15:32:50.000Z"}],"translations":[]}'
     http_version: 
-  recorded_at: Thu, 16 Aug 2018 20:07:41 GMT
+  recorded_at: Tue, 28 Aug 2018 09:20:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/helpers/components_helper_spec.rb
+++ b/spec/helpers/components_helper_spec.rb
@@ -16,4 +16,22 @@ RSpec.describe ComponentsHelper do
       end
     end
   end
+
+  describe '#define_path' do
+    context 'for article pages' do
+      let(:page_link) { { page_type: 'foo', slug: 'some-slug' } }
+      it 'returns an article path formatted with locale and slug' do
+        expect(helper.define_path(page_link)).to eq(
+          '/en/articles/some-slug'
+        )
+      end
+    end
+
+    context 'for static pages' do
+      let(:page_link) { { page_type: 'static', slug: 'impact-principles' } }
+      it 'returns a static_pages path actioned to the slug' do
+        expect(helper.define_path(page_link)).to eq('/en/impact-principles')
+      end
+    end
+  end
 end


### PR DESCRIPTION
[TP 9519](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&searchPopup=bug/9519)

### ISSUE
The links on the research and evaluation boxes do not point to a valid path, consequently an error is rendered.

### SOLUTION
- correct text and slug in the translations file where they are defined
- add a page type
- use a helper method to define the correct path based on page type