### PR TITLE
[DEV APPROVED] Remove pensions from Topic filter options

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,6 @@ en:
           - Other
         topics:
           - Saving
-          - Pensions
           - Pensions and retirement planning
           - Credit use and debt
           - Budgeting and keeping track

--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -7,7 +7,14 @@ Feature: Evidence Hub Search
     Given I visit the evidence hub search page
 
   Scenario: Visit the landing page
-    Then I should see the "first" evidence summary as
+    Then I should see a list of all search filters
+      | Field               | Value                                                        |
+      | Year of publication | All years, Last 2 years, Last 5 years, More than 5 years ago |
+      | Client group        | Children (3 - 11), Young people (12 - 16), Parents/families, Young adults (17 - 24), Working age (18 - 65), Older people (65+), Over-indebted people, Social housing tenants, Teachers/practitioners, Other |
+      | Topic               | Saving, Pensions and retirement planning, Credit use and debt, Budgeting and keeping track, Insurance and protection, Financial education, Financial capability |
+      | Country of delivery | United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other |
+    
+    And I should see the "first" evidence summary as
       | Field               | Value                                                    |
       | document title      | Financial well-being: the employee view                  |
       | overview            | Stress caused by pay levels, lack of financial awareness |

--- a/features/step_definitions/evidence_hub/show_steps.rb
+++ b/features/step_definitions/evidence_hub/show_steps.rb
@@ -15,6 +15,13 @@ When('I click {string}') do |text|
   click_link(text)
 end
 
+Then('I should see a list of all search filters') do |table|
+  table.rows.each do |row|
+    filters = evidence_summaries_page.find_filter_group(row[0]).filter_inputs
+    expect(filters.map(&:text)).to eq(row[1].split(', '))
+  end
+end
+
 Then('I should see the evidence summary content') do |table|
   table.rows.each do |row|
     field_name = row[0].parameterize.underscore

--- a/features/support/ui/pages/evidence_summaries.rb
+++ b/features/support/ui/pages/evidence_summaries.rb
@@ -19,6 +19,15 @@ module UI::Pages
       element :info_icon, 'a.icon--info'
     end
 
+    class FilterInput < SitePrism::Section
+      element :input, 'input'
+    end
+
+    class SearchFilter < SitePrism::Section
+      element :title, 'legend'
+      sections :filter_inputs, FilterInput, 'label'
+    end
+
     set_url '{/locale}/evidence_hub'
 
     # pagination elements
@@ -44,5 +53,10 @@ module UI::Pages
             '.evidence-hub__thematic-review-message a'
 
     sections :search_results, SearchResult, '.search-results__item'
+    sections :search_filters, SearchFilter, '.sidepanel__filters-inner .sidepanel__fieldset'
+
+    def find_filter_group(title)
+      search_filters.find { |filter_group| filter_group.title.text == title }
+    end
   end
 end


### PR DESCRIPTION
[TP 9294](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&searchPopup=userstory/9492)

### Requirement
There are 2 filters for the Topic filter group which are essentially the same and one has no documents. If you click on 'pensions' no documents appear and it is a poor user experience.

### Solution
Remove 'pensions' from the translations file.