### PR TITLE
[DEV APPROVED] - Fix for client group filters

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,13 +22,13 @@ en:
         client_groups:
           - Children (3 - 11)
           - Young people (12 - 16)
-          - Parents/families
+          - Parents / families
           - Young adults (17 - 24)
           - Working age (18 - 65)
           - Older people (65+)
           - Over-indebted people
           - Social housing tenants
-          - Teachers/practitioners
+          - Teachers / practitioners
           - Other
         topics:
           - Saving

--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -10,7 +10,7 @@ Feature: Evidence Hub Search
     Then I should see a list of all search filters
       | Field               | Value                                                        |
       | Year of publication | All years, Last 2 years, Last 5 years, More than 5 years ago |
-      | Client group        | Children (3 - 11), Young people (12 - 16), Parents/families, Young adults (17 - 24), Working age (18 - 65), Older people (65+), Over-indebted people, Social housing tenants, Teachers/practitioners, Other |
+      | Client group        | Children (3 - 11), Young people (12 - 16), Parents / families, Young adults (17 - 24), Working age (18 - 65), Older people (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other |
       | Topic               | Saving, Pensions and retirement planning, Credit use and debt, Budgeting and keeping track, Insurance and protection, Financial education, Financial capability |
       | Country of delivery | United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other |
     


### PR DESCRIPTION
[TP 9552](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&searchPopup=bug/9552)

### ISSUES

1. On the evidence hub search form, ticking the Client group search filters 'Parent/families' and 'Teachers/practitioners' do not returning correct results. 

1. When clicking on a filter in the Key Info panel for 'Parent / families' and 'Teachers / practitioners',
the corresponding filter on the search results page is not ticked.


### RESOLUTION
Both these issues are a result of the values on the fincap form not matching the values in the cms blocks, there is a space either side of the `/` on the search form. The quick fix is to update the values in translations file to match the ones in cms.