### PR TITLE
[DEV APPROVED] Retrieve ordered news with an `order_by_date` parameter

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,7 +1,4 @@
 class NewsController < FincapTemplatesController
-  LATEST_NEWS_DOCUMENT_TYPE = 'latest_news'.freeze
-  NEWS_DOCUMENT_TYPE = 'news'.freeze
-
   def resource
     NewsTemplate.new(Mas::Cms::News.find(params[:id]))
   end
@@ -9,16 +6,18 @@ class NewsController < FincapTemplatesController
 
   def index
     document = Mas::Cms::LatestNews.all(
-      params: { document_type: [LATEST_NEWS_DOCUMENT_TYPE] }
+      params: { document_type: [Mas::Cms::LatestNews::PAGE_TYPE] }
     ).first
     @index_page = LatestNewsTemplate.new(document)
   end
 
   def resource_collection
     documents = Mas::Cms::News.all(
-      params: { document_type: [NEWS_DOCUMENT_TYPE] }.merge(year_param)
+      params: {
+        document_type: [Mas::Cms::News::PAGE_TYPE],
+        order_by_date: true
+      }.merge(year_param)
     )
-    documents = TaggedNews.sort_by_published_date(documents)
     documents.map { |document| NewsTemplate.new(document) }
   end
   helper_method :resource_collection

--- a/app/models/tagged_news.rb
+++ b/app/models/tagged_news.rb
@@ -1,16 +1,11 @@
 class TaggedNews
-  def self.all(article)
-    news_items = Mas::Cms::News.all(
+  def self.all(page)
+    Mas::Cms::News.all(
       params: {
         document_type: [Mas::Cms::News::PAGE_TYPE],
-        tag: Array(article.tags)
+        tag: Array(page.tags),
+        order_by_date: true
       }
-    ).reject { |news_item| news_item.slug == article.slug }
-
-    sort_by_published_date(news_items)
-  end
-
-  def self.sort_by_published_date(news_items)
-    news_items.sort_by(&:published_date).reverse
+    ).reject { |news_item| news_item.slug == page.slug }
   end
 end

--- a/config/initializers/mas_cms_client.rb
+++ b/config/initializers/mas_cms_client.rb
@@ -26,14 +26,6 @@ end
 
 class Mas::Cms::News < Mas::Cms::Article
   PAGE_TYPE = 'news'.freeze
-
-  def published_date
-    content = non_content_blocks.find do |block|
-      block.identifier == 'order_by_date'
-    end.content
-
-    Date.parse(ActionView::Base.full_sanitizer.sanitize(content.strip))
-  end
 end
 
 class Mas::Cms::Review < Mas::Cms::Document

--- a/features/lifestage_page.feature
+++ b/features/lifestage_page.feature
@@ -1,6 +1,6 @@
 Feature: Lifestage page
-  As a user, 
-  I want to be able to read a lifestage page and easily find related content, 
+  As a user,
+  I want to be able to read a lifestage page and easily find related content,
   so that I can gather as much information as I require on this subject.
 
   Scenario: Visiting an Lifestage page
@@ -25,7 +25,7 @@ Feature: Lifestage page
     And I should see the research box
     And I should see the strategy box with
       | title            | text                                         | link                               |
-      | Strategy title   | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf | 
+      | Strategy title   | Research suggests that young adults typically display lower levels of financial capability than older age groups. | /exectutive+summary.pdf |
     And I should see the life stages box
     And I should see the steering group links
       | text                | link                       |

--- a/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_keyword_2017_order_by_date_true.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_keyword_2017_order_by_date_true.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/news.json?document_type%5B%5D=news&keyword=2017&order_by_date=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (M-C02W80LWGWN.local; giuseppelobraico; 36434) ruby/2.4.2
+        (198; x86_64-darwin17)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 03 Sep 2018 12:01:55 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"3323fd80ca7691c4c047cc946fa9845e"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - ecbf7382-c94a-4c5d-9330-49bc2fca5576
+      x-runtime:
+      - '0.161016'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"Scottish Financial Education Week","slug":"scottish-financial-education-week","full_path":"/en/news/scottish-financial-education-week","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2017-03-15
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]}],"meta":{"results":1,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 12:01:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true.yml
@@ -1,0 +1,155 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/news.json?document_type%5B%5D=news&order_by_date=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (M-C02W80LWGWN.local; giuseppelobraico; 36434) ruby/2.4.2
+        (198; x86_64-darwin17)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 03 Sep 2018 12:01:55 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"efc2c3ee7fd2892d4c17830646f5a1e8"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 969918a6-adbf-48dc-963a-c328b07e9104
+      x-runtime:
+      - '0.366744'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"News 1","slug":"news-1","full_path":"/en/news/news-1","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-11-19
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        2","slug":"news-2","full_path":"/en/news/news-2","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-10-18
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        3","slug":"news-3","full_path":"/en/news/news-3","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-09-17
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        4","slug":"news-4","full_path":"/en/news/news-4","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-08-16
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"Press
+        Release: A new way to pay!","slug":"press-release-a-new-way-to-pay","full_path":"/en/news/press-release-a-new-way-to-pay","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments","secure-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        way in which payments are made in the UK is set to undergo the most radical\nchange
+        since the 1960s. This follows the \u003ca href=\"https://www.paymentsforum.uk/final-strategy\"\u003elaunch
+        of a new strategy\u003c/a\u003e to give people\ngreater control over how they
+        manage their day-to-day finances and help stamp\nout financial fraud.\nIn
+        the first industry-wide initiative of its kind, the Payments Strategy Forum,\nwhose
+        members include consumer groups, businesses, fintechs, UK banks and\nbuilding
+        societies, today recommends a new way of making payments that promises\ngreater
+        protection and security for consumers and businesses.(2)\nThe Strategy gives:\n*   More
+        control and assurance for consumers over how they manage their finances\n*   Safer
+        and more secure banking\n*   Opportunities for new banks and Fintechs to compete
+        and offer innovative services that meet the needs of tomorrow’s users\nNotes
+        to editors\n1.  Source: The Payment Systems Regulator\n2.  The Payments Strategy
+        Forum (the Forum) was announced by the Payment Systems Regulator (PSR) in
+        its\nPolicy Statement published in March 2015.\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-07-26
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        5","slug":"news-5","full_path":"/en/news/news-5","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-07-15
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        6","slug":"news-6","full_path":"/en/news/news-6","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-06-14
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        7","slug":"news-7","full_path":"/en/news/news-7","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-05-13
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        8","slug":"news-8","full_path":"/en/news/news-8","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-04-12
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        9","slug":"news-9","full_path":"/en/news/news-9","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-03-11
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        10","slug":"news-10","full_path":"/en/news/news-10","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-02-10
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"Scottish
+        Financial Education Week","slug":"scottish-financial-education-week","full_path":"/en/news/scottish-financial-education-week","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2017-03-15
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]}],"meta":{"results":12,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 12:01:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true_.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true_.yml
@@ -1,0 +1,155 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/news.json?document_type%5B%5D=news&order_by_date=true&
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (M-C02W80LWGWN.local; giuseppelobraico; 36434) ruby/2.4.2
+        (198; x86_64-darwin17)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 03 Sep 2018 12:01:49 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"efc2c3ee7fd2892d4c17830646f5a1e8"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - cbdeeeeb-865e-4ff4-b3cf-731b919b240e
+      x-runtime:
+      - '2.649742'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"News 1","slug":"news-1","full_path":"/en/news/news-1","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-11-19
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        2","slug":"news-2","full_path":"/en/news/news-2","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-10-18
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        3","slug":"news-3","full_path":"/en/news/news-3","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-09-17
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        4","slug":"news-4","full_path":"/en/news/news-4","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-08-16
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"Press
+        Release: A new way to pay!","slug":"press-release-a-new-way-to-pay","full_path":"/en/news/press-release-a-new-way-to-pay","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments","secure-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        way in which payments are made in the UK is set to undergo the most radical\nchange
+        since the 1960s. This follows the \u003ca href=\"https://www.paymentsforum.uk/final-strategy\"\u003elaunch
+        of a new strategy\u003c/a\u003e to give people\ngreater control over how they
+        manage their day-to-day finances and help stamp\nout financial fraud.\nIn
+        the first industry-wide initiative of its kind, the Payments Strategy Forum,\nwhose
+        members include consumer groups, businesses, fintechs, UK banks and\nbuilding
+        societies, today recommends a new way of making payments that promises\ngreater
+        protection and security for consumers and businesses.(2)\nThe Strategy gives:\n*   More
+        control and assurance for consumers over how they manage their finances\n*   Safer
+        and more secure banking\n*   Opportunities for new banks and Fintechs to compete
+        and offer innovative services that meet the needs of tomorrow’s users\nNotes
+        to editors\n1.  Source: The Payment Systems Regulator\n2.  The Payments Strategy
+        Forum (the Forum) was announced by the Payment Systems Regulator (PSR) in
+        its\nPolicy Statement published in March 2015.\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-07-26
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        5","slug":"news-5","full_path":"/en/news/news-5","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-07-15
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        6","slug":"news-6","full_path":"/en/news/news-6","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-06-14
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        7","slug":"news-7","full_path":"/en/news/news-7","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-05-13
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        8","slug":"news-8","full_path":"/en/news/news-8","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-04-12
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        9","slug":"news-9","full_path":"/en/news/news-9","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-03-11
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"News
+        10","slug":"news-10","full_path":"/en/news/news-10","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-02-10
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]},{"label":"Scottish
+        Financial Education Week","slug":"scottish-financial-education-week","full_path":"/en/news/scottish-financial-education-week","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eA
+        great news!\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2017-03-15
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:54.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]}],"meta":{"results":12,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 12:01:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true_tag_mobile-payments.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/news_jsondocument_type_news_order_by_date_true_tag_mobile-payments.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/news.json?document_type%5B%5D=news&order_by_date=true&tag%5B%5D=mobile-payments
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (M-C02W80LWGWN.local; giuseppelobraico; 36434) ruby/2.4.2
+        (198; x86_64-darwin17)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 03 Sep 2018 12:01:50 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"4e523b09d69defc550b3520023651db9"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 4064a614-eb07-4f1e-95df-dea67c1806a8
+      x-runtime:
+      - '0.193227'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"Press Release: A new way to pay!","slug":"press-release-a-new-way-to-pay","full_path":"/en/news/press-release-a-new-way-to-pay","meta_description":null,"meta_title":null,"category_names":[],"layout_identifier":"news","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["mobile-payments","secure-payments"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        way in which payments are made in the UK is set to undergo the most radical\nchange
+        since the 1960s. This follows the \u003ca href=\"https://www.paymentsforum.uk/final-strategy\"\u003elaunch
+        of a new strategy\u003c/a\u003e to give people\ngreater control over how they
+        manage their day-to-day finances and help stamp\nout financial fraud.\nIn
+        the first industry-wide initiative of its kind, the Payments Strategy Forum,\nwhose
+        members include consumer groups, businesses, fintechs, UK banks and\nbuilding
+        societies, today recommends a new way of making payments that promises\ngreater
+        protection and security for consumers and businesses.(2)\nThe Strategy gives:\n*   More
+        control and assurance for consumers over how they manage their finances\n*   Safer
+        and more secure banking\n*   Opportunities for new banks and Fintechs to compete
+        and offer innovative services that meet the needs of tomorrow’s users\nNotes
+        to editors\n1.  Source: The Payment Systems Regulator\n2.  The Payments Strategy
+        Forum (the Forum) was announced by the Payment Systems Regulator (PSR) in
+        its\nPolicy Statement published in March 2015.\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_image","content":"\u003cp\u003e/assets/styleguide/hero-sample.jpg\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_hero_description","content":"\u003cp\u003eNew
+        strategy launched to make UK payments fit for the 21st Century\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"component_cta_links","content":"\u003cp\u003e\u003ca
+        href=\"/news\"\u003eLatest News\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"},{"identifier":"order_by_date","content":"\u003cp\u003e2018-07-26
+        00:00:00\u003c/p\u003e\n","created_at":"2018-09-03T10:42:53.000Z","updated_at":"2018-09-03T10:42:54.000Z"}],"translations":[]}],"meta":{"results":1,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 12:01:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/models/tagged_news_spec.rb
+++ b/spec/models/tagged_news_spec.rb
@@ -1,54 +1,23 @@
 RSpec.describe TaggedNews, type: :model do
-  let(:subject) { described_class.all(article) }
+  let(:subject) { described_class.all(page) }
 
-  describe '#all' do
-    let(:article) { Mas::Cms::Lifestage.find('young-adults') }
-
-    it 'does not return the article' do
-      expect(subject.include?(article)).to be_falsey
+  describe '.all' do
+    let(:page) { double('page', slug: 'homepage', tags: %w[one two]) }
+    let(:financial_capability_week) do
+      double('news', slug: 'financial-capability-week')
     end
+    let(:news) { [page, financial_capability_week] }
 
-    context 'sorting news by the published date' do
-      let(:article) { Mas::Cms::Homepage.find('root') }
-      let(:news_dates) do
-        subject.map(&:published_date)
-      end
+    it 'retrieves all the news for the page' do
+      expect(Mas::Cms::News).to receive(:all).with(
+        params: {
+          document_type: ['news'],
+          tag: %w[one two],
+          order_by_date: true
+        }
+      ).and_return(news)
 
-      it 'sorts news by date' do
-        expect(news_dates).to eq(
-          [
-            Date.new(2018, 11, 19),
-            Date.new(2018, 10, 18),
-            Date.new(2018, 9, 17),
-            Date.new(2018, 8, 16),
-            Date.new(2018, 7, 26),
-            Date.new(2018, 7, 15),
-            Date.new(2018, 6, 14),
-            Date.new(2018, 5, 13),
-            Date.new(2018, 4, 12),
-            Date.new(2018, 3, 11),
-            Date.new(2018, 2, 10),
-            Date.new(2017, 3, 15)
-          ]
-        )
-      end
-    end
-
-    context 'when the article has associated tags' do
-      it 'returns news items with the same tags as the article' do
-        subject.each do |news_item|
-          expect(news_item.tags.any? { |tag| article.tags.include?(tag) })
-            .to be_truthy
-        end
-      end
-    end
-
-    context 'when the article has no associated tags' do
-      let(:article) { Mas::Cms::Article.find('uk-strategy') }
-
-      it 'returns all the news items' do
-        expect(subject.count).to eq(12)
-      end
+      expect(subject).to eq([financial_capability_week])
     end
   end
 end


### PR DESCRIPTION
[TP 9500](https://moneyadviceservice.tpondemand.com/entity/9500-latest-news-component-doesnt-show-most)+[TP 9551](https://moneyadviceservice.tpondemand.com/entity/9551-news-page-does-not-show-all)

This PR is an alternative fix to the issue in the card.

The idea is that you should be ordering upfront, in order to avoid issues with pagination and filtering of huge arrays in memory.

Requires: https://github.com/moneyadviceservice/cms/pull/486