### PR TITLE
[DEV APPROVED] 9405 - Allow filter by Evidence type on Evidence Hub

### DIFF
--- a/app/controllers/evidence_hub_controller.rb
+++ b/app/controllers/evidence_hub_controller.rb
@@ -13,6 +13,7 @@ class EvidenceHubController < EvidenceSummariesController
     params.fetch(:evidence_summary_search_form, {}).permit(
       :keyword,
       :year_of_publication,
+      evidence_types: [],
       client_groups: [],
       topics: [],
       countries_of_delivery: [],
@@ -29,11 +30,7 @@ class EvidenceHubController < EvidenceSummariesController
   private
 
   def form_params
-    form_params = {
-      document_type: DOCUMENT_TYPES,
-      page: params[:page] || PAGINATION_DEFAULT_PAGE,
-      per_page: params[:per_page] || PAGINATION_PER_PAGE
-    }
+    form_params = form_base_params
     form_params[:tag] = params[:tag] if params[:tag].present?
 
     if clear_search?
@@ -41,6 +38,15 @@ class EvidenceHubController < EvidenceSummariesController
     else
       form_params.merge(evidence_summary_search_form_params)
     end
+  end
+
+  def form_base_params
+    {
+      document_type:
+        evidence_summary_search_form_params[:evidence_types] || DOCUMENT_TYPES,
+      page: params[:page] || PAGINATION_DEFAULT_PAGE,
+      per_page: params[:per_page] || PAGINATION_PER_PAGE
+    }
   end
 
   def search_params

--- a/app/controllers/evidence_hub_controller.rb
+++ b/app/controllers/evidence_hub_controller.rb
@@ -44,7 +44,7 @@ class EvidenceHubController < EvidenceSummariesController
   end
 
   def search_params
-    SearchFormParamParser.parse(form_params)
+    EvidenceHub::SearchFormParamParser.parse(form_params)
   end
 
   def reset_all_params

--- a/app/forms/evidence_summary_search_form.rb
+++ b/app/forms/evidence_summary_search_form.rb
@@ -13,7 +13,8 @@ class EvidenceSummarySearchForm
                 :tag,
                 :measured_outcomes
 
-  CHECKBOX_FILTERS = %w[client_groups topics countries_of_delivery].freeze
+  CHECKBOX_FILTERS =
+    %w[client_groups evidence_types topics countries_of_delivery].freeze
   RADIO_BUTTON_FILTERS = %w[year_of_publication].freeze
 
   def self.checkbox_filters

--- a/app/services/evidence_hub/search_form_param_parser.rb
+++ b/app/services/evidence_hub/search_form_param_parser.rb
@@ -1,8 +1,6 @@
-class SearchFormParamParser
-  FINCAP_START_YEAR = 2000
-  IGNORED_OPTION = 'All years'.freeze
-  YEAR_OF_PUBLICATION_FILTER = 'year_of_publication'.freeze
+class EvidenceHub::SearchFormParamParser
   KEY_INFO_FILTER = 'measured_outcomes'.freeze
+  MULTI_OPTION_FILTERS = EvidenceSummarySearchForm.checkbox_filters
 
   attr_accessor :params
 
@@ -37,17 +35,24 @@ class SearchFormParamParser
   end
 
   def blocks_hash(filters)
-    query_filters(filters).map do |id, values|
-      if year_of_publication?(id)
-        identifier_hash(id, years_array(values))
+    filters.map do |key, values|
+      if MULTI_OPTION_FILTERS.include? key
+        multi_option_hash(key, values)
       else
-        values.map { |value| identifier_hash(id, value) }
+        single_option_hash(key, values)
       end
-    end
+    end.compact
   end
 
-  def query_filters(filters)
-    filters.reject { |_, v| v == IGNORED_OPTION }
+  def multi_option_hash(key, values)
+    values.map { |value| identifier_hash(key, value) }
+  end
+
+  def single_option_hash(key, value)
+    if key == EvidenceHub::YearOfPublicationParser::FILTER
+      value = EvidenceHub::YearOfPublicationParser.parse(value)
+    end
+    identifier_hash(key, value) if value
   end
 
   def identifier_hash(id, value)
@@ -57,24 +62,6 @@ class SearchFormParamParser
   def filter_keys
     EvidenceSummarySearchForm.checkbox_filters +
       EvidenceSummarySearchForm.radio_button_filters
-  end
-
-  def year_of_publication?(id)
-    id == YEAR_OF_PUBLICATION_FILTER
-  end
-
-  def years_array(option)
-    years_range[option].map do |n|
-      n.year.ago.strftime('%Y').to_i
-    end
-  end
-
-  def years_range
-    {
-      'Last 2 years' => (0..1),
-      'Last 5 years' => (0..4),
-      'More than 5 years ago' => (5..(Time.current.year - FINCAP_START_YEAR))
-    }
   end
 
   def key_info_filters(hash)

--- a/app/services/evidence_hub/search_form_param_parser.rb
+++ b/app/services/evidence_hub/search_form_param_parser.rb
@@ -1,6 +1,7 @@
 class EvidenceHub::SearchFormParamParser
   KEY_INFO_FILTER = 'measured_outcomes'.freeze
   MULTI_OPTION_FILTERS = EvidenceSummarySearchForm.checkbox_filters
+  IGNORED_FILTERS = ['evidence_types'].freeze
 
   attr_accessor :params
 
@@ -27,7 +28,7 @@ class EvidenceHub::SearchFormParamParser
   private
 
   def parse_filters(filters)
-    blocks = blocks_hash(filters).flatten
+    blocks = blocks_hash(allowed_filters(filters)).flatten
 
     return {} if blocks.blank?
 
@@ -66,6 +67,10 @@ class EvidenceHub::SearchFormParamParser
 
   def key_info_filters(hash)
     hash[KEY_INFO_FILTER]
+  end
+
+  def allowed_filters(filters)
+    filters.reject { |k, _| IGNORED_FILTERS.include? k }
   end
 
   def convert_key_info_filters(key_info)

--- a/app/services/evidence_hub/year_of_publication_parser.rb
+++ b/app/services/evidence_hub/year_of_publication_parser.rb
@@ -1,0 +1,29 @@
+module EvidenceHub::YearOfPublicationParser
+  IGNORED_OPTION = 'All years'.freeze
+  FILTER = 'year_of_publication'.freeze
+  FINCAP_START_YEAR = 2000
+
+  class << self
+    def parse(year_option)
+      return if year_option == IGNORED_OPTION
+
+      years_array(year_option)
+    end
+
+    private
+
+    def years_array(option)
+      years_range[option]&.map do |n|
+        n.year.ago.strftime('%Y').to_i
+      end
+    end
+
+    def years_range
+      {
+        'Last 2 years' => (0..1),
+        'Last 5 years' => (0..4),
+        'More than 5 years ago' => (5..(Time.current.year - FINCAP_START_YEAR))
+      }
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,10 @@ en:
           - Social housing tenants
           - Teachers / practitioners
           - Other
+        evidence_types:
+          - Evaluation
+          - Insight
+          - Review
         topics:
           - Saving
           - Pensions and retirement planning

--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -11,6 +11,7 @@ Feature: Evidence Hub Search
       | Field               | Value                                                        |
       | Year of publication | All years, Last 2 years, Last 5 years, More than 5 years ago |
       | Client group        | Children (3 - 11), Young people (12 - 16), Parents / families, Young adults (17 - 24), Working age (18 - 65), Older people (65+), Over-indebted people, Social housing tenants, Teachers / practitioners, Other |
+      | Evidence type       | Evaluation, Insight, Review |
       | Topic               | Saving, Pensions and retirement planning, Credit use and debt, Budgeting and keeping track, Insurance and protection, Financial education, Financial capability |
       | Country of delivery | United Kingdom, England, Northern Ireland, Scotland, Wales, USA, Other |
     And I should see the "first" evidence summary as
@@ -83,6 +84,40 @@ Feature: Evidence Hub Search
       | countries           | England                                                            |
       | year of publication | 2017                                                               |
     And I should see the "first" evidence summary icon linking to "Insight" article
+
+  Scenario: Search by single evidence type filter
+    When I search the evidence hub for summaries of type "Evaluation"
+    Then I should see "1" evidence summary
+    And I should see the "first" evidence summary as
+      | Field               | Value                       |
+      | document title      | Looking after the pennies   |
+      | evidence type       | Evaluation                  |
+      | topics              | Budgeting and keeping track |
+      | countries           | United Kingdom              |
+      | year of publication | 2017                        |
+    And I should see the "first" evidence summary icon linking to "Evaluation" article
+
+  Scenario: Search by multiple evidence types filter
+    When I search the evidence hub for summaries of types "Insight" and "Review"
+    Then I should see "3" evidence summary
+    And I should see the "first" evidence summary as
+      | Field               | Value                                                    |
+      | document title      | Financial well-being: the employee view                  |
+      | overview            | Stress caused by pay levels, lack of financial awareness |
+      | evidence type       | Insight                                                  |
+      | topics              | Saving                                                   |
+      | countries           | United Kingdom                                           |
+      | year of publication | 2015                                                     |
+    And I should see the "first" evidence summary icon linking to "Insight" article
+    And I should see the "third" evidence summary as
+      | Field               | Value                                                         |
+      | document title      | Raising household saving                                      |
+      | overview            | Based on an analysis of international evidence                |
+      | evidence type       | Review                                                        |
+      | topics              | Saving, Pensions and Retirement Planning, Financial Education |
+      | countries           | International review                                          |
+      | year of publication | 2012                                                          |
+    And I should see the "third" evidence summary icon linking to "Review" article
 
   Scenario: Clearing the filters for a filtered search
     Given I search based on some filters

--- a/features/step_definitions/evidence_hub/search_steps.rb
+++ b/features/step_definitions/evidence_hub/search_steps.rb
@@ -19,6 +19,19 @@ When('I search the evidence hub for summaries published in the last 2 years') do
   step %(I press search)
 end
 
+When('I search the evidence hub for summaries of type {string}') do |type|
+  step %(I visit the evidence hub search page)
+  evidence_summaries_page.send("#{type.downcase}_filter").set(true)
+  step %(I press search)
+end
+
+When('I search the evidence hub for summaries of types {string} and {string}') do |first_type, second_type|
+  step %(I visit the evidence hub search page)
+  evidence_summaries_page.send("#{first_type.downcase}_filter").set(true)
+  evidence_summaries_page.send("#{second_type.downcase}_filter").set(true)
+  step %(I press search)
+end
+
 When('I go to the next evidence hub page') do
   evidence_summaries_page.next_page.click
 end

--- a/features/support/ui/pages/evidence_summaries.rb
+++ b/features/support/ui/pages/evidence_summaries.rb
@@ -51,6 +51,12 @@ module UI::Pages
             '#evidence_summary_search_form_client_groups_children-3-11'
     element :last_2_years_filter,
             '#evidence_summary_search_form_year_of_publication_last-2-years'
+    element :evaluation_filter,
+            '#evidence_summary_search_form_evidence_types_evaluation'
+    element :insight_filter,
+            '#evidence_summary_search_form_evidence_types_insight'
+    element :review_filter,
+            '#evidence_summary_search_form_evidence_types_review'
     element :clear_filters_button, '.sidepanel__clear-filters'
 
     element :thematic_review_message, '.evidence-hub__thematic-review-message'

--- a/spec/cassettes/fincap_cms/get/api/en/documents_jsondocument_type_Evaluation_keyword_page_1_per_page_20.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/documents_jsondocument_type_Evaluation_keyword_page_1_per_page_20.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/documents.json?document_type%5B%5D=Evaluation&keyword=&page=1&per_page=20
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (bichito; marc; 25632) ruby/2.4.2 (198; x86_64-linux)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 03 Sep 2018 11:53:50 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"1cf8c59586865cc3c7e5f0eab6dea771"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 149b60ac-cd03-42f5-a67e-7e287f56b359
+      x-runtime:
+      - '0.038066'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"Looking after the pennies","slug":"looking-after-the-pennies","full_path":"/en/evaluations/looking-after-the-pennies","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"evaluation","related_content":{"latest_blog_post_links":[{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"},{"title":"5
+        things students can teach YOU about money","path":"https://www.moneyadviceservice.org.uk/blog/5-things-students-can-teach-you-about-money"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["how-can-we-improve-the-financial-capability-of-young-adults"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        trackers are all available as free smartphone apps (although at the\ntime
+        of writing, Toshl is discontinued). Overall user numbers of the apps\nare
+        not given. However, 797 customers entered into the project (by\ncompleting
+        a first questionnaire and downloading an app) from across\nthe UK between
+        July and November 2016.\u003c/p\u003e\n\n\u003cp\u003eThe intervention was
+        undertaken in participants’ own time as part their\ndaily lives.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"overview","content":"\u003cp\u003eAn
+        evaluation, commissioned by Royal London, of the impacts of using\n        simple
+        budgeting tools on customers’ money management attitudes and\n        behaviours.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eWorking
+        age (18 - 65)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOlder
+        people (65+)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"topics","content":"\u003cp\u003eBudgeting
+        and keeping track\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"activities_and_setting","content":"\u003cp\u003eComparison
+        of budgeting apps vs. pen and paper methods\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"programme_delivery","content":"\u003cp\u003eMoney
+        Advice\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"countries","content":"\u003cp\u003eUnited
+        Kingdom\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2017\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"data_types","content":"\u003cp\u003eMeasured
+        Outcomes\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://www.royallondon.com/Documents/PDFs/2017/Royal%20London%20-%20Looking%20after%20the%20pennies.pdf\"\u003eLooking
+        after the pennies - full report\u003c/a\u003e\u003c/p\u003e\n\n\u003cpre\u003e\u003ccode\u003e  [Follow-up
+        report](https://fincap-two.cdn.prismic.io/fincap-two%2F0efeee0b-252a-4b13-b7f5-d05e66bdc6aa_final+report+-+royal+london+fincap.pptx)\n\u003c/code\u003e\u003c/pre\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"contact_information","content":"\u003cp\u003eMASPD
+        (in partnership with Company S.A)\n        T +44 (0)20 1234 5678 F +44 (0)20
+        4567 1234\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"measured_outcomes","content":"\u003cp\u003eFinancial
+        capability (Mindset)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"measured_outcomes","content":"\u003cp\u003eFinancial
+        capability (Ability)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"}],"translations":[]}],"meta":{"results":1,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Mon, 03 Sep 2018 11:53:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/fincap_cms/get/api/en/documents_jsondocument_type_Insight_document_type_Review_keyword_page_1_per_page_20.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/documents_jsondocument_type_Insight_document_type_Review_keyword_page_1_per_page_20.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/documents.json?document_type%5B%5D=Insight&document_type%5B%5D=Review&keyword=&page=1&per_page=20
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (bichito; marc; 16515) ruby/2.4.2 (198; x86_64-linux)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Thu, 06 Sep 2018 13:22:37 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"bed9ec4523a20ce70ecf28d082bd8b53"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - '02106922-7cc9-401d-a074-247126ebb460'
+      x-runtime:
+      - '0.235995'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"Financial well-being: the employee view","slug":"financial-well-being-the-employee-view","full_path":"/en/insights/financial-well-being-the-employee-view","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"insight","related_content":{"latest_blog_post_links":[{"title":"How
+        much deposit do I need for a mortgage?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-deposit-need-mortgage"},{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eContext\u003c/p\u003e\n\n\u003cp\u003eThe
+        survey explores employees’ views on attitudes to finances.\nStress caused
+        by pay levels, lack of financial awareness or absence of\nemployee benefits
+        can affect work performance.\nIn addition, the perception that their contributions
+        are not being\nacknowledged can have an impact on employee self-esteem, health
+        and\nproductivity.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"overview","content":"\u003cp\u003eThe
+        survey explores employees’ views on attitudes to finances.\n        Stress
+        caused by pay levels, lack of financial awareness or absence of\n        employee
+        benefits can affect work performance.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"countries","content":"\u003cp\u003eUnited
+        Kingdom\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://www.cipd.co.uk/Images/financial-well-being-employee-view-report_tcm18-17439.pdf\"\u003eFinancial
+        well-being: the employee view - full report\u003c/a\u003e’\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"contact_information","content":"\u003cp\u003eMASPD
+        (in partnership with Company S.A)\n        T +44 (0)20 1234 5678 F +44 (0)20
+        4567 1234\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2015\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"topics","content":"\u003cp\u003eSaving\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"topics","content":"\u003cp\u003eFinancial
+        Capability\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOver-indebted
+        people\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"data_types","content":"\u003cp\u003eQualitative\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"}],"translations":[]},{"label":"Moving
+        forward together: peer support for people with problem debt","slug":"moving-forward-together-peer-support-for-people-with-problem-debt","full_path":"/en/insights/moving-forward-together-peer-support-for-people-with-problem-debt","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"insight","related_content":{"latest_blog_post_links":[{"title":"How
+        much deposit do I need for a mortgage?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-deposit-need-mortgage"},{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eContext\u003c/p\u003e\n\n\u003cp\u003eResearch
+        has found that there remains a real stigma around seeking advice\nfor debt,
+        with many people feeling that doing so means that they have\n ‘failed’, but
+        that talking about debt problems is also cathartic.\nThis suggests there is
+        potential value in peer-support for over-indebted\npeople, based on models
+        in other fields such as weight loss.\u003c/p\u003e\n\n\u003cp\u003ePeer support
+        is usually intended to encourage behaviour change and is\nprovided by peer
+        mentors (those who have led or given support within\npeer support programmes).\u003c/p\u003e\n\n\u003cp\u003eSuch
+        innovation, however, needs an evidence base, so research was needed\nto explore
+        the peer-support landscape and establish how it helps people\nto resolve their
+        difficulties and change their behaviour.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2017\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://masassets.blob.core.windows.net/cms/files/000/000/631/original/MAS_MovingForwardTogether_Report.pdf\"\u003eMoving
+        forward together: peer support for people with problem debt - full report\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"contact_information","content":"\u003cp\u003epeersupport@moneyadviceservice.org.uk\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"overview","content":"\u003cp\u003eResearch
+        has found that there remains a real stigma around seeking\n        advice
+        for debt, with many people feeling that doing so means that\n        they
+        have ‘failed’, but that talking about debt problems is also\n        cathartic.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"countries","content":"\u003cp\u003eEngland\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"topics","content":"\u003cp\u003eCredit
+        Use and Debt\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOver-indebted
+        people\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eWorking
+        age (18 - 65)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:13.000Z","updated_at":"2018-08-30T19:44:15.000Z"}],"translations":[]},{"label":"Raising
+        household saving","slug":"raising-household-saving","full_path":"/en/reviews/raising-household-saving","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"review","related_content":{"latest_blog_post_links":[{"title":"How
+        much deposit do I need for a mortgage?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-deposit-need-mortgage"},{"title":"How
+        to minimise the biggest costs of going to university","path":"https://www.moneyadviceservice.org.uk/blog/how-to-minimise-the-biggest-costs-of-going-to-university"},{"title":"Release
+        your inner star baker and save","path":"https://www.moneyadviceservice.org.uk/blog/release-your-inner-star-baker-and-save"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["how-can-we-improve-the-financial-capability-of-young-adults"],"blocks":[{"identifier":"content","content":"\u003cp\u003eContext\u003c/p\u003e\n\n\u003cp\u003eThere
+        is continuing concern in the UK and internationally that many individuals
+        are making insufficient savings, especially for retirement. This has long
+        been a key issue in UK policy discussions – demonstrated by the continual
+        modifications to the retirement pension system throughout the 21st century
+        (and before).\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2012\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://www.britac.ac.uk/sites/default/files/BRI1089_household_saving_report_02.12_WEB_FINAL.pdf\"\u003eRaising
+        household saving - full report\u003c/a\u003e\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"contact_information","content":"\u003cp\u003eJohn
+        Smith, John Smith\u003c/p\u003e\n\n\u003cp\u003eInstitute for Studies\u003c/p\u003e\n\n\u003cp\u003ehttps://www.company-name.org.uk/\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"overview","content":"\u003cp\u003eBased
+        on an analysis of international evidence, this report examines in detail what
+        is known – and what is not known – about the effectiveness of different sorts
+        of interventions designed to raise household savings.\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"countries","content":"\u003cp\u003eInternational
+        review\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"topics","content":"\u003cp\u003eSaving\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"topics","content":"\u003cp\u003ePensions
+        and Retirement Planning\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"topics","content":"\u003cp\u003eFinancial
+        Education\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eChildren
+        (3 - 11)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eYoung
+        people (12 - 16)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eParents
+        / families\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eYoung
+        adults (17 - 24)\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"},{"identifier":"data_types","content":"\u003cp\u003eSystematic
+        review\u003c/p\u003e\n","created_at":"2018-08-30T19:44:14.000Z","updated_at":"2018-08-30T19:44:16.000Z"}],"translations":[]}],"meta":{"results":3,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Thu, 06 Sep 2018 13:22:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/forms/evidence_summary_search_form_spec.rb
+++ b/spec/forms/evidence_summary_search_form_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe EvidenceSummarySearchForm do
 
   describe '.checkbox_filters' do
     it 'returns an array of the multi-select filters' do
-      filters = %w[client_groups topics countries_of_delivery]
+      filters = %w[client_groups evidence_types topics countries_of_delivery]
 
       expect(described_class.checkbox_filters).to eq(filters)
     end

--- a/spec/services/evidence_hub/search_form_param_parser_spec.rb
+++ b/spec/services/evidence_hub/search_form_param_parser_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe SearchFormParamParser, type: :model do
+RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:subject) { described_class.new(params) }
 
   describe '#parse' do
@@ -126,6 +128,9 @@ RSpec.describe SearchFormParamParser, type: :model do
     context 'with a publication year filter' do
       let(:filter) { 'year_of_publication' }
 
+      before { travel_to Time.zone.local(2018, 8, 4, 1, 15, 30) }
+      after { travel_back }
+
       context 'set to All years' do
         let(:params) { { keyword: '', filter => 'All years' } }
         let(:expected_result) { { keyword: '' } }
@@ -139,9 +144,7 @@ RSpec.describe SearchFormParamParser, type: :model do
         let(:params) { { keyword: '', filter => 'Last 2 years' } }
         let(:expected_result) { { keyword: '', blocks: blocks } }
         let(:blocks) { [{ identifier: filter, value: years }] }
-        let(:years) do
-          ((Time.current.year - 1)..(Time.current.year)).to_a.reverse
-        end
+        let(:years) { [2018, 2017] }
 
         it 'returns an array of 2 year values and the keyword hash' do
           expect(subject.parse).to eq(expected_result)
@@ -152,9 +155,7 @@ RSpec.describe SearchFormParamParser, type: :model do
         let(:params) { { keyword: '', filter => 'Last 5 years' } }
         let(:expected_result) { { keyword: '', blocks: blocks } }
         let(:blocks) { [{ identifier: filter, value: years }] }
-        let(:years) do
-          ((Time.current.year - 4)..(Time.current.year)).to_a.reverse
-        end
+        let(:years) { [2018, 2017, 2016, 2015, 2014] }
 
         it 'returns array of 5 year values and the keyword hash' do
           expect(subject.parse).to eq(expected_result)
@@ -165,7 +166,7 @@ RSpec.describe SearchFormParamParser, type: :model do
         let(:params) { { keyword: '', filter => 'More than 5 years ago' } }
         let(:expected_result) { { keyword: '', blocks: blocks } }
         let(:blocks) { [{ identifier: filter, value: years }] }
-        let(:years) { (2000..(Time.current.year - 5)).to_a.reverse }
+        let(:years) { 2013.downto(2000).to_a }
 
         it 'returns array of years btwn (now - 5) to 2000 and keyword hash' do
           expect(subject.parse).to eq(expected_result)

--- a/spec/services/evidence_hub/search_form_param_parser_spec.rb
+++ b/spec/services/evidence_hub/search_form_param_parser_spec.rb
@@ -187,5 +187,20 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
         expect(subject.parse).to eq(expected_result)
       end
     end
+
+    context 'with a filter included in the list of ignored' do
+      let(:params) do
+        {
+          'evidence_types' => ['Insight'],
+          'topics' => ['Saving']
+        }
+      end
+
+      it 'excludes it from the parsed output' do
+        expect(subject.parse).to eq(
+          blocks: [{ identifier: 'topics', value: 'Saving' }]
+        )
+      end
+    end
   end
 end

--- a/spec/services/evidence_hub/year_of_publication_parser_spec.rb
+++ b/spec/services/evidence_hub/year_of_publication_parser_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe EvidenceHub::YearOfPublicationParser do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe '.parse' do
+    subject(:parser_output) { described_class.parse(year_option) }
+
+    before { travel_to Time.zone.local(2018, 8, 4, 1, 15, 30) }
+    after { travel_back }
+
+    context 'when the year option is last 2 years' do
+      let(:year_option) { 'Last 2 years' }
+
+      it 'returns last two years' do
+        expect(parser_output).to eq([2018, 2017])
+      end
+    end
+
+    context 'when the year option is last 5 years' do
+      let(:year_option) { 'Last 5 years' }
+
+      it 'returns last 5 years' do
+        expect(parser_output).to eq([2018, 2017, 2016, 2015, 2014])
+      end
+    end
+
+    context 'when the year option is more than 5 years ago' do
+      let(:year_option) { 'More than 5 years ago' }
+
+      it 'return all years from when Fincap started until 6 years ago' do
+        expect(parser_output).to eq(2013.downto(2000).to_a)
+      end
+    end
+
+    context 'when the year option is all years' do
+      let(:year_option) { 'All years' }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the year option is anything else' do
+      let(:year_option) { '2 million years ago' }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
[TP-9405](https://moneyadviceservice.tpondemand.com/entity/9405-add-evidence-type-to-ev-hub)

- We want to be able to filter the Evidence Hub results by the "Evidence type".
- This PR also includes some refactor in the Search Form Parser in order to isolate responsibilities and allow future extension of the class.
- I recommend to review it Commit by Commit.

Page to check: (`/en/evidence_hub`)

## After the Changes

### Without selecting any option
![screenshot from 2018-09-06 10-36-14](https://user-images.githubusercontent.com/1227578/45149196-e6ded300-b1c0-11e8-9147-92a95add3c89.png)

### Filtering by a single type
![screenshot from 2018-09-06 10-36-47](https://user-images.githubusercontent.com/1227578/45149205-e8100000-b1c0-11e8-9f9b-b2ca02eb03c1.png)

### Filtering by multiple types
![screenshot from 2018-09-06 10-37-10](https://user-images.githubusercontent.com/1227578/45149207-ea725a00-b1c0-11e8-8a9f-0673abd3050e.png)

