### PR TITLE
[DEV APPROVED] Style evidence summaries to indicate if they are new or not

### DIFF
--- a/app/models/evidence_summary.rb
+++ b/app/models/evidence_summary.rb
@@ -1,6 +1,8 @@
 class EvidenceSummary
   extend ActiveModel::Translation
 
+  IS_NEW_PERIOD = 90
+
   def self.map(documents)
     documents.map { |document| new(document) }
   end
@@ -69,6 +71,10 @@ class EvidenceSummary
     find_blocks(:data_types)
   end
 
+  def recent?
+    created_at.present? && created_at > (Time.current - IS_NEW_PERIOD.days)
+  end
+
   private
 
   def find_blocks(block_identifier)
@@ -91,5 +97,9 @@ class EvidenceSummary
     else
       fields['content']
     end
+  end
+
+  def created_at
+    blocks.find(:content).first&.fetch('created_at', nil)
   end
 end

--- a/app/presenters/evidence_summary_presenter.rb
+++ b/app/presenters/evidence_summary_presenter.rb
@@ -116,6 +116,10 @@ class EvidenceSummaryPresenter < BasePresenter
     search_form_params('measured_outcomes' => [value.humanize])
   end
 
+  def new_css_class
+    recent? ? 'is-new' : ''
+  end
+
   private
 
   def translate_field(field)

--- a/app/views/evidence_hub/_search_result.html.erb
+++ b/app/views/evidence_hub/_search_result.html.erb
@@ -1,5 +1,5 @@
 <li class="search-results__item">
-  <p class="search-results__title">
+  <p class="search-results__title <%= document.new_css_class %>">
     <%= document.link %>
   </p>
   <p class="search-results__description">

--- a/app/views/evidence_summaries/_content.html.erb
+++ b/app/views/evidence_summaries/_content.html.erb
@@ -1,4 +1,4 @@
-<h1 class="evidence-hub__title">
+<h1 class="evidence-hub__title <%= evidence_summary.new_css_class %>">
   <%= evidence_summary.title %>
 </h1>
 

--- a/spec/models/evidence_summary_spec.rb
+++ b/spec/models/evidence_summary_spec.rb
@@ -285,4 +285,38 @@ RSpec.describe EvidenceSummary do
       end
     end
   end
+
+  describe '#recent?' do
+    let(:blocks) do
+      [
+        {
+          'identifier' => 'content', 'content' => '<p>Content</p>'
+        }.merge(created_at)
+      ]
+    end
+
+    context 'when the date is later than 90 days ago' do
+      let(:created_at) { { 'created_at' => (Time.current - 5.days).to_s } }
+
+      it 'returns true' do
+        expect(evidence_summary.recent?).to be_truthy
+      end
+    end
+
+    context 'when the date is earlier than 90 days ago' do
+      let(:created_at) { { 'created_at' => (Time.current - 90.days).to_s } }
+
+      it 'returns true' do
+        expect(evidence_summary.recent?).to be_falsey
+      end
+    end
+
+    context 'when there is no content block' do
+      let(:created_at) { {} }
+
+      it 'returns empty string' do
+        expect(evidence_summary.recent?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/presenters/evidence_summary_presenter_spec.rb
+++ b/spec/presenters/evidence_summary_presenter_spec.rb
@@ -327,4 +327,26 @@ RSpec.describe EvidenceSummaryPresenter do
       expect(presenter.topic_filter_params('bar')).to eq expected_result
     end
   end
+
+  describe '#new_css_class' do
+    before do
+      allow(evidence_summary).to receive(:recent?).and_return(recent?)
+    end
+
+    context 'when the evidence_summary is recently created' do
+      let(:recent?) { true }
+
+      it 'returns "is_new"' do
+        expect(presenter.new_css_class).to eq('is-new')
+      end
+    end
+
+    context 'when the evidence_summary has been around for awhile' do
+      let(:recent?) { false }
+
+      it 'returns an empty string' do
+        expect(presenter.new_css_class).to eq('')
+      end
+    end
+  end
 end


### PR DESCRIPTION
[TP 8924](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5481321774608038243&appConfig=eyJhY2lkIjoiNjRGM0FCMDY3RUQ5MDREM0RGNDZGOUM0REZENUZBMzIifQ==&boardPopup=userstory/8924/silent)

### REQUIREMENT
Display evidence summaries and evidence hub search results with an indicator that allows users to identify which documents are new.

Specifically, evidence summaries which have been created less than 90 days ago will be styled with a 'new' tag. This tag should display on both the individual summary page and for each document in the search results, where appropriate.

<img width="825" alt="screen shot 2018-09-03 at 16 29 04" src="https://user-images.githubusercontent.com/3481059/44994440-94ba6980-af96-11e8-9a92-9e3bd37f6bc5.png">

<img width="689" alt="screen shot 2018-09-03 at 16 29 17" src="https://user-images.githubusercontent.com/3481059/44994444-9be17780-af96-11e8-9f7e-e3fba1bac557.png">


### SOLUTION
- presenter method to check the created_at date for the content block
  and returns the styleguide class or an empty string
- use the presenter method in the the search results and the evidence
  summary views