### PR TITLE
[DEV APPROVED] 9539 Hero Images Safari Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bower.json
 bower_components
 node_modules
 .rubocop-*
+
+# Ignore webstorm preferences
+.idea/

--- a/app/assets/stylesheets/components/ui/_hero.scss
+++ b/app/assets/stylesheets/components/ui/_hero.scss
@@ -4,6 +4,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
+  padding-top: 12.5rem;
 
   @include respond-to($mq-m) {
     height: 0;
@@ -18,7 +19,6 @@
   background-color: $primary-green-pale;
   color: $color-white;
   padding: $baseline-unit*4 $baseline-unit*3;
-  margin-top: 12.5rem;
   margin-bottom: 0;
 
   .hero__heading-strong,


### PR DESCRIPTION
[9539]( https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=bug/9539/silent)
Fix for this small defect, in Safari, it seems that the margin on the h1 gets ignored so the contain div does not display the background image.  To fix I removed the margin and added padding to the containing div.

Checked in FF, Safari and Chrome