### PR TITLE
[DEV APPROVED] 9544 nav life stages mobile view

### DIFF
--- a/app/assets/javascripts/components/Nav.js
+++ b/app/assets/javascripts/components/Nav.js
@@ -290,7 +290,6 @@ define(['jquery', 'DoughBaseComponent', 'utilities', 'mediaQueries'], function($
     this._attachBoundHelper(this.$mobileNavClose, this._toggleMobileNav, this);
     this._attachBoundHelper(this.$navLevel_1_Heading, this._openMobileLevel2, this);
     this._attachBoundHelper(this.$navLevel_2_Heading, this._closeMobileLevel2, this);
-    this._attachBoundHelper(this.$navLevel_2_Extended_Heading, this._toggleMobileLevel3, this);
     this._attachBoundHelper(this.$navLevel_3_Heading, this._toggleMobileLevel3, this);
   };
 
@@ -409,17 +408,6 @@ define(['jquery', 'DoughBaseComponent', 'utilities', 'mediaQueries'], function($
       .parents('[data-nav-level-1-item]').toggleClass(this.activeClass)
       .parents('[data-nav-level-1]').toggleClass(this.activeClass);
   }
-
-  /**
-  * Toggles nav level 3 on mobile
-  */
-  Nav.prototype._toggleMobileLevel3 = function(index) {
-    if (this.atSmallViewport) {
-      this.$navLevel_1.toggleClass(this.openClass);
-      this.$navLevel_3.removeClass(this.activeClass);
-      $(index).siblings('[data-nav-level-3]').toggleClass(this.activeClass)
-    }
-  };
 
   /**
    * Opens Level 2 on desktop

--- a/app/assets/stylesheets/components/nav/_nav_level_2.scss
+++ b/app/assets/stylesheets/components/nav/_nav_level_2.scss
@@ -35,7 +35,7 @@
     &:after {
       content: '';
       display: block;
-      @include box-shadow($spread: 6px); 
+      @include box-shadow($spread: 6px);
       position: relative;
       z-index: -1
     }
@@ -283,20 +283,17 @@
 
   @include respond-to($mq-m) {
     padding-right: calc(#{$chevron-size * $chevron-ratio} + #{$default-gutter * 8});
-  }
 
-  &:after {
-    @include chevron(right, $primary-orange, $chevron-size);
+    &:after {
+      @include chevron(right, $primary-orange, $chevron-size);
 
-    display: block;
-    position: absolute;
-    top: 50%;
-    right: $default-gutter;
-    transform: translateY(-$chevron-size * 2);
-
-    @include respond-to($mq-m) {
       right: $default-gutter * 4;
       transform: translateY(-$chevron-size * 1);
+      display: block;
+      position: absolute;
+      top: 50%;
+      right: $default-gutter;
+      transform: translateY(-$chevron-size * 2);
     }
   }
 }

--- a/spec/javascripts/tests/Nav_spec.js
+++ b/spec/javascripts/tests/Nav_spec.js
@@ -95,13 +95,7 @@ describe('Nav', function() {
       this.toggleMobileNavStub = sinon.stub(this.obj, "_toggleMobileNav");
       this.openMobileLevel2Stub = sinon.stub(this.obj, "_openMobileLevel2");
       this.closeMobileLevel2Stub = sinon.stub(this.obj, "_closeMobileLevel2");
-      this.toggleMobileLevel3Stub = sinon.stub(this.obj, "_toggleMobileLevel3");
       this.obj.init();
-    });
-
-    it('Calls the _toggleMobileNav method when the mobile nav button is clicked', function() {
-      this.mobileNavButton.trigger('click');
-      expect(this.toggleMobileNavStub.callCount).to.be.equal(1);
     });
 
     it('Calls the _toggleMobileNav method when the mobile nav overlay is clicked', function() {
@@ -122,16 +116,6 @@ describe('Nav', function() {
     it('Calls the _closeMobileLevel2 method when each Level 2 Heading is clicked', function() {
       var count = countCalls(this.$navLevel2, 'data-nav-level-2-heading');
       expect(this.closeMobileLevel2Stub.callCount).to.be.equal(count);
-    });
-
-    it('Calls the _toggleMobileLevel3 method when each Level 2 Extended Heading is clicked', function() {
-      var count = countCalls(this.$navLevel2ExtendedItems, 'data-nav-level-2-extended-heading');
-      expect(this.toggleMobileLevel3Stub.callCount).to.be.equal(count);
-    });
-
-    it('Calls the _toggleMobileLevel3 method when each Level 3 Heading is clicked', function() {
-      var count = countCalls(this.$navLevel3, 'data-nav-level-3-heading');
-      expect(this.toggleMobileLevel3Stub.callCount).to.be.equal(count);
     });
   });
 
@@ -435,64 +419,6 @@ describe('Nav', function() {
       callCloseMobileLevel2();
       this.obj.atSmallViewport = false;
       callCloseMobileLevel2();
-    });
-  });
-
-  describe('Calls _toggleMobileLevel3 to open level', function() {
-    it('Displays the level 3 menu associated with the level 2 target element at mobile view', function() {
-      var self = this;
-      var callOpenMobileLevel3 = function() {
-        self.$navLevel2ExtendedItems.each(function() {
-          $(this).find('[data-nav-level-2-extended-heading]').each(function() {
-            self.$navLevel1.removeClass(self.openClass);
-            self.$navLevel3.removeClass(self.activeClass);
-
-            self.obj._toggleMobileLevel3(this);
-
-            if (self.obj.atSmallViewport) {
-              expect($(this).siblings('[data-nav-level-3]').hasClass(self.activeClass)).to.be.true;
-              expect($(this).parents('[data-nav-level-1]').hasClass(self.openClass)).to.be.true;
-            } else {
-              expect($(this).siblings('[data-nav-level-3]').hasClass(self.activeClass)).to.be.false;
-              expect($(this).parents('[data-nav-level-1]').hasClass(self.openClass)).to.be.false;
-            }
-          });
-        });
-      }
-
-      this.obj.atSmallViewport = true;
-      callOpenMobileLevel3();
-      this.obj.atSmallViewport = false;
-      callOpenMobileLevel3();
-    });
-  });
-
-  describe('Calls _toggleMobileLevel3 to close level', function() {
-    it('Closes the live level 3 menu and displays the parent level 2 menu at mobile view', function() {
-      var self = this;
-      var callCloseMobileLevel3 = function() {
-        self.$navLevel3.each(function() {
-          var index = $(this).find('[data-nav-level-3-heading]');
-
-          self.$navLevel1.addClass(self.openClass);
-          $(this).addClass(self.activeClass);
-
-          self.obj._toggleMobileLevel3($(index).parents('[data-nav-level-3]'));
-
-          if (self.obj.atSmallViewport == true) {
-            expect(self.$navLevel1.hasClass(self.openClass)).to.be.false;
-            expect($(this).hasClass(self.activeClass)).to.be.false;
-          } else {
-            expect(self.$navLevel1.hasClass(self.openClass)).to.be.true;
-            expect($(this).hasClass(self.activeClass)).to.be.true;
-          }
-        });
-      }
-
-      this.obj.atSmallViewport = true;
-      callCloseMobileLevel3();
-      this.obj.atSmallViewport = false;
-      callCloseMobileLevel3();
     });
   });
 


### PR DESCRIPTION
[TP9544](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=bug/9544/silent)

This PR is to enable the clickable functionality on the Life Stages links on all views and disable the third level of links on mobile (these will still be accessed from the landing pages). 

The tests associated with the now-redundant mobile view functionality are also removed.

Additionally there is a small visual change associated with this: I have removed the chevrons from the life stages links on the mobile view, which currently suggest a further level would be displayed. 

### Current

![image](https://user-images.githubusercontent.com/6080548/45104405-f65f0d00-b129-11e8-95d1-8f3367f2d0b0.png)

### Updated

![image](https://user-images.githubusercontent.com/6080548/45104455-0ecf2780-b12a-11e8-8ad5-ad1e3525bdef.png)
