### PR TITLE
[DEV APPROVED] 9562 get involved page copy and link updates

### DIFF
--- a/app/views/static_pages/be_involved.html.erb
+++ b/app/views/static_pages/be_involved.html.erb
@@ -22,7 +22,7 @@
         <dd class="list--numbered__content">
           <%= raw t(
             'fincap.get_involved.list.use.content_html',
-            link_evaluation_toolkit: (link_to 'Evaluation Toolkit', 'evaluation-toolkit-homepage'),
+            link_evaluation_toolkit: (link_to 'Evaluation Toolkit', article_path('en', 'evaluation-toolkit-overview')),
             link_evidence_hub: (link_to 'Evidence Hub', evidence_hub_index_path)) %>
         </dd>
         <dt class="list--numbered__title">
@@ -30,14 +30,13 @@
         </dt>
         <dd class="list--numbered__content">
           <%= raw t('fincap.get_involved.list.talk_money_week.content_html',
-            link: (link_to 'here', 'fincap-week')) %>
+            link: (link_to 'here', article_path('en', 'talk-money-week'))) %>
         </dd>
         <dt class="list--numbered__title">
           <%= t('fincap.get_involved.list.up_to_date.title') %>
         </dt>
         <dd class="list--numbered__content">
           <%= raw t('fincap.get_involved.list.up_to_date.content_html',
-            link_themes: (link_to 'Themes page', 'themes'),
             link_twitter: (link_to 'Twitter', t('fincap.links_external.twitter')),
             link_linkedin: (link_to 'LinkedIn', t('fincap.links_external.linkedin'))) %>
         </dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,7 @@ en:
           content_html: 'This themed week raises awareness of the importance of financial capability, what it means and the organisations involved in making a change. We’d love to hear from organisations interested in getting involved – more information is available %{link}.'
         up_to_date:
           title: Keep up to date
-          content_html: 'Read our research and get updates from the steering group on our %{link_themes}, and don’t forget to follow the Strategy’s official %{link_twitter} and %{link_linkedin} profile.'
+          content_html: 'Read our research and get updates from the steering group on our Lifestages pages, and don’t forget to follow the Strategy’s official %{link_twitter} and %{link_linkedin} profile.'
         share:
           title: Share your news
           content_html: 'Whatever you’re up to, we want to hear from you. We’re always on the lookout for news from across the world of Financial Capability. If your organisation has any relevant news you’d like to share, or if you would like to write a guest blog, get in touch at %{link}.'


### PR DESCRIPTION
[TP9562](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=bug/9562/silent)

Not all the links are available on localhost but they are not the prod version

Updated links and text as per ticket
Evaluation toolkit link goes to articles/evaluation-toolkit-overview
Item number 3 links to articles/talk-money-week
Item 4 text has changed to "Read our research and get updates from the steering group on our Lifestages pages, and don’t forget to follow the Strategy’s official Twitter and LinkedIn profile."