### PR TITLE
[DEV APPROVED] 9378 Added in twitter feed to article page, basic styling

### DIFF
--- a/app/assets/stylesheets/components/ui/_sidepanel.scss
+++ b/app/assets/stylesheets/components/ui/_sidepanel.scss
@@ -122,3 +122,9 @@
   display: block;
   padding: $baseline-unit/2 0;
 }
+
+.sidepanel__twitter {
+  margin: $baseline-spacing 0;
+  padding: 30px;
+  background: $color-blue-aqua;
+}

--- a/app/assets/stylesheets/lib/_variables.scss
+++ b/app/assets/stylesheets/lib/_variables.scss
@@ -23,6 +23,7 @@ $color-red-pale: #E95E50;
 $color-green-dark: #008996;
 $color-green-lime: #8CC635;
 $color-blue-lighter: #e5ebf5;
+$color-blue-aqua: #66cccc;
 
 // Greys
 

--- a/app/views/fincap_templates/show.html.erb
+++ b/app/views/fincap_templates/show.html.erb
@@ -17,6 +17,9 @@
       </div>
       <div class="l-2col-side">
         <%= template.cta_links_component %>
+        <%= render "/shared/twitter_feed" %>
+
+
         <%= template.download_component %>
         <%= template.feedback_component %>
       </div>

--- a/app/views/shared/_twitter_feed.html.erb
+++ b/app/views/shared/_twitter_feed.html.erb
@@ -1,0 +1,4 @@
+<div class='sidepanel__twitter'>
+    <%= link_to('Tweets by FinCapStrategy', 'https://twitter.com/FinCapStrategy', {'class': 'twitter-timeline', 'data-height': '750', 'data-theme': 'light', 'data-aria-polite': 'assertive'}) %>
+    <script async src="//platform.twitter.com/widgets.js" chars  et="utf-8"></script>
+</div>


### PR DESCRIPTION
[9378](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=userstory/9378&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==)

This PR is to add the MAS twitter feed to the right hand area of all article pages.
Created a new component in the shared file and added to the show.html.erb file


Checked in FF, Safari, Chrome and responsively
![image](https://user-images.githubusercontent.com/1598761/45294693-0b55ea80-b4f4-11e8-86a8-bcd5bcfc9bd7.png)
