### PR TITLE
Experimental fix for js not loading on Safari

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,6 +12,7 @@ Rails.application.config.assets.paths << Rails.root.join('bower_components')
 Rails.application.config.assets.precompile += %w[
   components/*.js
   dough/assets/js/components/*.js
+  rsvp/*.js
 ]
 
 # Vendor JavaScript


### PR DESCRIPTION
[9567](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=bug/9567/silent)

Small change to try and bring in rsvp in Safari, as this throws an error.

WIP: Do not merge