### PR TITLE
Show Key Info headings only if there is information beneath them

### DIFF
--- a/app/views/evaluations/_activities_and_setting.html.erb
+++ b/app/views/evaluations/_activities_and_setting.html.erb
@@ -1,6 +1,8 @@
-<div class="evidence-hub__activities_and_setting">
-  <h5 class="sidepanel__subtitle">
-    <%= evidence_summary.activities_and_setting_field_name %>
-  </h5>
-  <%= evidence_summary.stripped_activities_and_setting %>
-</div>
+<% if evidence_summary.stripped_activities_and_setting.present? %>
+  <div class="evidence-hub__activities_and_setting">
+    <h5 class="sidepanel__subtitle">
+      <%= evidence_summary.activities_and_setting_field_name %>
+    </h5>
+    <%= evidence_summary.stripped_activities_and_setting %>
+  </div>
+<% end %>

--- a/app/views/evaluations/_measured_outcomes.html.erb
+++ b/app/views/evaluations/_measured_outcomes.html.erb
@@ -1,17 +1,19 @@
-<div class="evidence-hub__measured_outcomes">
-  <h5 class="sidepanel__subtitle">
-    <%= evidence_summary.measured_outcomes_field_name %>
-  </h5>
-  <ul class="sidepanel__list">
-    <% evidence_summary.stripped_measured_outcomes.each do |outcome| %>
-      <li class="sidepanel__list-item">
-        <%= link_to outcome,
-            evidence_hub_index_path(
-              params: evidence_summary.measured_outcome_filter_params(outcome)
-            ),
-            class: 'sidepanel__list-item-link'
-        %>
-      </li>
-    <% end %>
-  </ul>
-</div>
+<% if evidence_summary.stripped_measured_outcomes.present? %>
+  <div class="evidence-hub__measured_outcomes">
+    <h5 class="sidepanel__subtitle">
+      <%= evidence_summary.measured_outcomes_field_name %>
+    </h5>
+    <ul class="sidepanel__list">
+      <% evidence_summary.stripped_measured_outcomes.each do |outcome| %>
+        <li class="sidepanel__list-item">
+          <%= link_to outcome,
+              evidence_hub_index_path(
+                params: evidence_summary.measured_outcome_filter_params(outcome)
+              ),
+              class: 'sidepanel__list-item-link'
+          %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/evaluations/_programme_delivery.html.erb
+++ b/app/views/evaluations/_programme_delivery.html.erb
@@ -1,6 +1,8 @@
-<div class="evidence-hub__programme_delivery">
-  <h5 class="sidepanel__subtitle">
-    <%= evidence_summary.programme_delivery_field_name %>
-  </h5>
-  <%= evidence_summary.stripped_programme_delivery %>
-</div>
+<% if evidence_summary.stripped_programme_delivery.present? %>
+  <div class="evidence-hub__programme_delivery">
+    <h5 class="sidepanel__subtitle">
+      <%= evidence_summary.programme_delivery_field_name %>
+    </h5>
+    <%= evidence_summary.stripped_programme_delivery %>
+  </div>
+<% end %>

--- a/features/evaluation_summary_page.feature
+++ b/features/evaluation_summary_page.feature
@@ -27,3 +27,11 @@ Feature: Evidence Hub: Evaluation Summary page
       | causality                   | cross |
       | process_evaluation          | cross |
       | value_for_money             | cross |
+
+  Scenario: Remove key info if blank values
+    Given I entered into the "Evaluation" page "Evaluation without some blocks"
+    Then I should not see the evidence summary field
+      | Field                  |
+      | Activities and setting |
+      | Measured outcomes      |
+      | Programme delivery     |

--- a/features/step_definitions/evidence_hub/show_steps.rb
+++ b/features/step_definitions/evidence_hub/show_steps.rb
@@ -71,3 +71,10 @@ end
 Then('I should see {string} evidence summaries') do |number|
   expect(evidence_summaries_page.search_results.count).to eq(number.to_i)
 end
+
+Then("I should not see the evidence summary field") do |table|
+  table.rows.each do |row|
+    field = row[0].parameterize.underscore
+    expect(evidence_summary_page).to_not send("have_#{field}")
+  end
+end

--- a/spec/cassettes/fincap_cms/get/api/en/evaluations/evaluation-without-some-blocks_json.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/evaluations/evaluation-without-some-blocks_json.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/evaluations/evaluation-without-some-blocks.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.17.0 (Tomas-Destefi-00119.local; tomasdestefi; 80673) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Wed, 12 Sep 2018 14:37:22 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"599f662bb52b84b7454f2b5173ed22df"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 8796a717-54e2-4ebe-a11e-9cba1e0a3998
+      x-runtime:
+      - '0.070765'
+    body:
+      encoding: UTF-8
+      string: '{"label":"Evaluation without some blocks","slug":"evaluation-without-some-blocks","full_path":"/en/evaluations/evaluation-without-some-blocks","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"evaluation","related_content":{"latest_blog_post_links":[{"title":"How
+        much does it cost to keep a dog?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-does-it-cost-to-keep-a-dog"},{"title":"How
+        much does a divorce cost?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-does-a-divorce-cost"},{"title":"How
+        much deposit do I need for a mortgage?","path":"https://www.moneyadviceservice.org.uk/blog/how-much-deposit-need-mortgage"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        trackers are all available as free smartphone apps (although at the\ntime
+        of writing, Toshl is discontinued). Overall user numbers of the apps\nare
+        not given. However, 797 customers entered into the project (by\ncompleting
+        a first questionnaire and downloading an app) from across\nthe UK between
+        July and November 2016.\u003c/p\u003e\n\n\u003cp\u003eThe intervention was
+        undertaken in participants’ own time as part their\ndaily lives.\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"overview","content":"\u003cp\u003eAn
+        evaluation, commissioned by Royal London, of the impacts of using\n        simple
+        budgeting tools on customers’ money management attitudes and\n        behaviours.\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eWorking
+        age (18 - 65)\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOlder
+        people (65+)\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"topics","content":"\u003cp\u003eBudgeting
+        and keeping track\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"countries","content":"\u003cp\u003eUnited
+        Kingdom\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2017\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"data_types","content":"\u003cp\u003eMeasured
+        Outcomes\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://www.royallondon.com/Documents/PDFs/2017/Royal%20London%20-%20Looking%20after%20the%20pennies.pdf\"\u003eLooking
+        after the pennies - full report\u003c/a\u003e\u003c/p\u003e\n\n\u003cpre\u003e\u003ccode\u003e  [Follow-up
+        report](https://fincap-two.cdn.prismic.io/fincap-two%2F0efeee0b-252a-4b13-b7f5-d05e66bdc6aa_final+report+-+royal+london+fincap.pptx)\n\u003c/code\u003e\u003c/pre\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"},{"identifier":"contact_information","content":"\u003cp\u003eMASPD
+        (in partnership with Company S.A)\n        T +44 (0)20 1234 5678 F +44 (0)20
+        4567 1234\u003c/p\u003e\n","created_at":"2018-09-12T14:34:45.000Z","updated_at":"2018-09-12T14:34:45.000Z"}],"translations":[]}'
+    http_version: 
+  recorded_at: Wed, 12 Sep 2018 14:37:22 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/9493-remove-key-info-titles-if-empty)

## Context

Key info section headlines will sometimes show up even if there is nothing beneath them. We would like these headings to appear only if there is appropriate info to display for them.

Talking with Venetia she was specific to only add this logic to three fields:

Activity and settings
Measured outcomes
Programme delivered by
