### PR TITLE
[DEV APPROVED] Remove hard coded funding link from main nav

### DIFF
--- a/app/views/shared/nav/_nav.html.erb
+++ b/app/views/shared/nav/_nav.html.erb
@@ -410,7 +410,6 @@
                   <%= render 'shared/nav/level_2_subcategory_heading', text: 'Evaluate your programme', url: article_path('en', 'evaluate-your-programme') %>
                   <%= render 'shared/nav/level_2_subcategory_link', text: 'Evaluation Toolkit', url: article_path('en', 'evaluation-toolkit-overview') %>
                   <%= render 'shared/nav/level_2_subcategory_link', text: 'Impact Principles', url: '/en/impact-principles' %>
-                  <%= render 'shared/nav/level_2_subcategory_link', text: 'Funding', url: article_path('en', 'funding') %>
                 </ul>
               </li>
 


### PR DESCRIPTION
[9571](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=userstory/9571/silent)

This PR is to remove the hard coded link to funding found in Research and Evaluation > Funding

**Old nav**
![image](https://user-images.githubusercontent.com/1598761/45615097-7870ff00-ba63-11e8-9ae3-db2df9365ecd.png)


**New nav**
![image](https://user-images.githubusercontent.com/1598761/45615134-92aadd00-ba63-11e8-9b93-c481db0108da.png)
