### PR TITLE
[DEV APPROVED] Add Google tag manager top application.html.erb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,28 @@
   </head>
 
   <body>
+    <%# START Google Tag Manager embed code %>
+    <% if Rails.env.production? %>
+    <noscript>
+      <iframe src="//www.googletagmanager.com/ns.html?id=<%= Rails.application.config.google_tag_manager_id %>"
+              height="0" width="0" style="display:none;visibility:hidden"
+              title="Google Tag Manager"></iframe>
+    </noscript>
+    <script>
+        (function(w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f.nextSibling);
+        })(window, document, 'script', 'dataLayer', '<%= Rails.application.config.google_tag_manager_id %>');
+    </script>
+    <% end %>
+    <%# END Google Tag Manager embed code %>
+
+
     <%= render 'shared/header' %>
     <%= render 'shared/nav/nav' %>
     <%= yield %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Google analytics
+    config.google_tag_manager_id = 'GTM-WVFLH9'
 end


### PR DESCRIPTION
[9588](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=userstory/9588)

Added google tag managers to application.html.erb.
Followed the example in the [Frontend project](https://github.com/moneyadviceservice/frontend) rather than follow what was in the ticket.
Not sure if this can be tested except on production