### PR TITLE
[DEV APPROVED] Add class and style to level2 subcategory links

### DIFF
--- a/app/assets/stylesheets/components/nav/_nav_level_2.scss
+++ b/app/assets/stylesheets/components/nav/_nav_level_2.scss
@@ -271,7 +271,7 @@
 
 .nav__level-2__category__heading__text,
 .nav__level-3__category__heading,
-.nav__level-3__subcategory__text,
+.nav__level-3__subcategory__link,
 .nav__level-3__heading__text {
   display: block;
   padding-bottom: $baseline-unit * 2;
@@ -319,6 +319,13 @@
 
 .nav__level-2__subcategory__heading {
   color: $primary-orange;
+}
+
+.nav__level-3__subcategory__link,
+.nav__level-2__subcategory__link {
+  &:visited {
+    color: $primary-blue;
+  }
 }
 
 /* FlexBox compliant -- */

--- a/app/assets/stylesheets/components/nav/_nav_level_3.scss
+++ b/app/assets/stylesheets/components/nav/_nav_level_3.scss
@@ -150,7 +150,7 @@
 }
 
 .nav__level-3__category__heading,
-.nav__level-3__subcategory__text {
+.nav__level-3__subcategory__link {
   color: $primary-blue-dark;
   border-color: $primary-orange;
 }

--- a/app/views/shared/nav/_level_2_subcategory_link.html.erb
+++ b/app/views/shared/nav/_level_2_subcategory_link.html.erb
@@ -3,6 +3,7 @@
     text,
     url,
     'data-nav-level-2-subcategory-link': true,
+    'class': 'nav__level-2__subcategory__link',
     'role': 'menuitem',
     'aria-haspopup': false,
     'tabindex': -1

--- a/app/views/shared/nav/_level_3_subcategory_link.html.erb
+++ b/app/views/shared/nav/_level_3_subcategory_link.html.erb
@@ -3,7 +3,7 @@
     text,
     url,
     'data-nav-level-3-link': true,
-    'class': 'nav__level-3__subcategory__text',
+    'class': 'nav__level-3__subcategory__link',
     'role': 'menuitem',
     'aria-haspopup': false,
     'tabindex': -1


### PR DESCRIPTION
[9578](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=userstory/9578/silent)

This PR is to prevent the subcategory links having the a visited colour of orange so that they can be distinguished from the heading links.
Added a class to the the subcategory links and kept the visited colour as the same blue as the default non-visited state

New state
![image](https://user-images.githubusercontent.com/1598761/45764809-6c379e00-bc2b-11e8-8fcc-4a00c7f6aa44.png)

