### PR TITLE
[DEV APPROVED] - Align client groups checkbox option naming in unit tests

### DIFF
--- a/spec/requests/evidence_hub_spec.rb
+++ b/spec/requests/evidence_hub_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Evidence Hub Summaries', type: :request do
           evidence_summary_search_form: {
             keyword: '',
             year_of_publication: 'All years',
-            client_groups: ['Young people (12 - 16)', 'Parents/families']
+            client_groups: ['Young people (12 - 16)', 'Parents / families']
           }
         }
       end
@@ -70,7 +70,7 @@ RSpec.describe 'Evidence Hub Summaries', type: :request do
             },
             {
               identifier: 'client_groups',
-              value: 'Parents/families'
+              value: 'Parents / families'
             }
           ]
         }

--- a/spec/services/evidence_hub/search_form_param_parser_spec.rb
+++ b/spec/services/evidence_hub/search_form_param_parser_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
         }
       end
 
-      let(:client_groups) { ['Young people (12 - 16)', 'Parents/families'] }
+      let(:client_groups) { ['Young people (12 - 16)', 'Parents / families'] }
 
       let(:expected_result) do
         {
@@ -59,7 +59,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
           blocks:
           [
             { identifier: 'client_groups', value: 'Young people (12 - 16)' },
-            { identifier: 'client_groups', value: 'Parents/families' }
+            { identifier: 'client_groups', value: 'Parents / families' }
           ]
         }
       end
@@ -78,7 +78,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
         }
       end
 
-      let(:client_groups) { ['Young people (12 - 16)', 'Parents/families'] }
+      let(:client_groups) { ['Young people (12 - 16)', 'Parents / families'] }
 
       let(:expected_result) do
         {
@@ -87,7 +87,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
           [
             { identifier: 'topics', value: 'Saving' },
             { identifier: 'client_groups', value: 'Young people (12 - 16)' },
-            { identifier: 'client_groups', value: 'Parents/families' }
+            { identifier: 'client_groups', value: 'Parents / families' }
           ]
         }
       end
@@ -106,7 +106,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
         }
       end
 
-      let(:client_groups) { ['Young people (12 - 16)', 'Parents/families'] }
+      let(:client_groups) { ['Young people (12 - 16)', 'Parents / families'] }
 
       let(:expected_result) do
         {
@@ -115,7 +115,7 @@ RSpec.describe EvidenceHub::SearchFormParamParser, type: :model do
           [
             { identifier: 'topics', value: 'Saving' },
             { identifier: 'client_groups', value: 'Young people (12 - 16)' },
-            { identifier: 'client_groups', value: 'Parents/families' }
+            { identifier: 'client_groups', value: 'Parents / families' }
           ]
         }
       end


### PR DESCRIPTION
To be consistent with the changes introduced with https://github.com/moneyadviceservice/fin_cap/pull/196 and https://github.com/moneyadviceservice/cms/pull/494.

Please note that this is not strictly required as the unit tests in subject are stubbing the response/checking the way the filtering works (hence no need to use real names).