### PR TITLE
[DEV APPROVED] Dont show news items on thematic review pages

### DIFF
--- a/app/controllers/thematic_reviews_controller.rb
+++ b/app/controllers/thematic_reviews_controller.rb
@@ -15,9 +15,6 @@ class ThematicReviewsController < FincapTemplatesController
 
   def show
     @thematic_review = Mas::Cms::ThematicReview.find(params[:id])
-    @latest_news = TaggedNews.all(@thematic_review).map do |news_item|
-      NewsTemplate.new(news_item)
-    end
   end
 
   def resource

--- a/app/views/thematic_reviews/show.html.erb
+++ b/app/views/thematic_reviews/show.html.erb
@@ -18,7 +18,6 @@
         </div>
       </div>
       <div class="l-2col-side">
-        <%= render 'shared/latest_news', latest_news: @latest_news %>
         <%= template.cta_links_component %>
         <%= template.download_component %>
         <%= template.feedback_component %>

--- a/features/thematic_review_page.feature
+++ b/features/thematic_review_page.feature
@@ -11,11 +11,6 @@ Feature: Thematic review page
     """
     Thematic Review content
     """
-    And I should see the news items details
-      | title  | published date           | link            |
-      | News 1 | Monday 19 November 2018  | /en/news/news-1 |
-      | News 2 | Thursday 18 October 2018 | /en/news/news-2 |
-      | News 3 | Monday 17 September 2018 | /en/news/news-3 |
     And I should see the call to action box containing the links
       | text                                                    | link                                                                             |
       | Evidence Summaries Associated with this Thematic Review | /en/evidence_hub?tag=how-can-we-improve-the-financial-capability-of-young-adults |


### PR DESCRIPTION
[TP 9560](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&searchPopup=userstory/9560)

### TECHNICAL
- Delete the api call for tagged news
- Remove the news partial from thematic reviews show view