### PR TITLE
[DEV APPROVED] 9589 search box update

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -36,8 +36,8 @@ $header-transition-ease: ease-out;
 }
 
 .header-content {
-  @extend %clearfix; 
-  @extend .l-constrained; 
+  @extend %clearfix;
+  @extend .l-constrained;
   box-sizing: border-box;
   display: flex;
   padding: $baseline-unit;
@@ -91,7 +91,7 @@ $header-transition-ease: ease-out;
 }
 .header-links__link {
   @extend .header-content__right-nav;
-  a {      
+  a {
     padding: $baseline-unit;
     color: $primary-blue-dark;
     font-weight: 500;
@@ -140,8 +140,8 @@ $header-transition-ease: ease-out;
   transition: visibility 0ms linear $speed-transition;
 }
 .mobile-header__search-bar {
+  @include column(12);
   display: inline-flex;
-  width: 100%;
   transform: translateY(-100%);
   transition: transform $speed-transition $header-transition-ease;
   background: $color-blue-lighter;
@@ -149,6 +149,9 @@ $header-transition-ease: ease-out;
     padding: 0 $baseline-unit;
     box-sizing: border-box;
     width: 100%;
+  }
+  .search__form-inner {
+    height: calc(40px + #{$baseline-unit*2});
   }
   .search__input {
     width: calc(100% - 40px - #{$baseline-unit*2});

--- a/app/assets/stylesheets/components/ui/_search_results.scss
+++ b/app/assets/stylesheets/components/ui/_search_results.scss
@@ -32,12 +32,11 @@ input.search__input--inpage {
   width: 100%;
   padding-right: 35px;
   padding-left: 20px;
-
-  @include respond-to($mq-m) {
-    width: 50%;
-  }
 }
 
-.search__submit--icon {
-  display: none;
+.search__container .search__form-inner {
+  @include respond-to($mq-m) {
+    position: relative;
+    width: 50%;
+  }
 }

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,14 +1,18 @@
 <%= form_tag search_results_path(locale: 'en'), method: :get, class: 'search' do %>
-  <%= label_tag 'Search', nil, for: "search_#{location}", class: 'visually-hidden' %>
-  <%= text_field_tag 'query',
-                     nil,
-                     placeholder: 'Search FinCap',
-                     id: "search_#{location}",
-                     class: "search__input search__input--#{location}"
-  %>
+  <div class="search__form-inner">
+    <%= label_tag 'Search', nil, for: "search_#{location}", class: 'visually-hidden' %>
+    <%= text_field_tag 'query',
+                       nil,
+                       placeholder: 'Search',
+                       id: "search_#{location}",
+                       class: "search__input search__input--#{location}"
+    %>
 
-  <button class='search__submit search__submit--icon' type="submit">
-    <span class="visually-hidden">Search</span>
-    <span class="icon icon--search"></span>
-  </button>
+    <button class='search__submit search__submit--icon' type="submit">
+      <span class="visually-hidden">Search</span>
+      <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--search" focusable="false">
+        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--search"></use>
+      </svg>
+    </button>
+  </div>
 <% end %>


### PR DESCRIPTION
[TP9589](https://moneyadviceservice.tpondemand.com/entity/9589-update-search-box-hint-text-and)

This PR 

- puts back the search svg icon into the search partial

- updates the search bar text

- tweaks styling to keep the search bar icon inside the bar on the search results page

It can be seen in the header (desktop and mobile), footer, and on the search results page

**PLEASE NOTE** this pr is currently branching off another fincap ticket, this is simply so that they can both go onto a qa environment together

<img width="399" alt="screen shot 2018-09-26 at 14 27 39" src="https://user-images.githubusercontent.com/3898629/46083058-73652b80-c198-11e8-83e7-35d5ede4382b.png">
<img width="397" alt="screen shot 2018-09-26 at 14 27 56" src="https://user-images.githubusercontent.com/3898629/46083059-73652b80-c198-11e8-89f2-8b738c165c57.png">
<img width="389" alt="screen shot 2018-09-26 at 14 28 06" src="https://user-images.githubusercontent.com/3898629/46083060-73652b80-c198-11e8-8ab9-eec4a16c0b1e.png">
<img width="378" alt="screen shot 2018-09-26 at 14 28 12" src="https://user-images.githubusercontent.com/3898629/46083062-73652b80-c198-11e8-9c19-3b9eedc35cfb.png">
