### PR TITLE
[DEV APPROVED] TP9587, Comment: Updates display order of components

### DIFF
--- a/app/assets/stylesheets/components/ui/_download_box.scss
+++ b/app/assets/stylesheets/components/ui/_download_box.scss
@@ -1,6 +1,7 @@
 .download-box {
   background-color: $primary-green-pale;
   padding: $baseline-unit*2;
+  margin: $baseline-spacing 0;
   color: $color-white;
   position: relative;
 }
@@ -20,7 +21,7 @@
   padding: 0;
   margin-bottom: 0;
   &,
-  .body-content & { 
+  .body-content & {
     list-style: none;
   }
 }

--- a/app/assets/stylesheets/components/ui/_feedback_box.scss
+++ b/app/assets/stylesheets/components/ui/_feedback_box.scss
@@ -1,7 +1,7 @@
 .feedback-box {
-  @extend %vertical-spacing;
   background-color: $primary-blue;
   padding: $baseline-unit*2;
+  margin: $baseline-spacing 0;
   color: $color-white;
 }
 

--- a/app/assets/stylesheets/components/ui/_sidepanel.scss
+++ b/app/assets/stylesheets/components/ui/_sidepanel.scss
@@ -124,7 +124,7 @@
 }
 
 .sidepanel__twitter {
-  margin: $baseline-spacing 0;
+  margin: $baseline-spacing 0 0;
   padding: 30px;
   background: $color-blue-aqua;
 }

--- a/app/views/fincap_templates/show.html.erb
+++ b/app/views/fincap_templates/show.html.erb
@@ -19,11 +19,9 @@
       </div>
       <div class="l-2col-side">
         <%= template.cta_links_component %>
-        <%= render "/shared/twitter_feed" %>
-
-
         <%= template.download_component %>
         <%= template.feedback_component %>
+        <%= render "/shared/twitter_feed" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
[TP9587](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiNzEyRUZDMzlENEJERUE4QjJBRDVEQzdENUE1MEE2OEIifQ==&boardPopup=userstory/9587/silent)

This updates the display order of components on the Right Hand Side of the articles pages, which currently displays the Twitter feed in the wrong position. 

Additionally it adds some consistency to the vertical spacing of the components which is effected by this change. 

**Current**
![image](https://user-images.githubusercontent.com/6080548/46088570-8c73d980-c1a4-11e8-9239-143061252032.png)

**Updated**
![image](https://user-images.githubusercontent.com/6080548/46088595-9564ab00-c1a4-11e8-8b8c-1613f1d518ad.png)

