### PR TITLE
[DEV APPROVED] - 9613 Add cookie message

### DIFF
--- a/app/assets/javascripts/components/Cookie.js
+++ b/app/assets/javascripts/components/Cookie.js
@@ -1,0 +1,47 @@
+define(['jquery', 'DoughBaseComponent'], function($, DoughBaseComponent) {
+   'use strict';
+   var Cookie;
+
+    Cookie = function($el, config) {
+        this.$el = $el;
+        Cookie.baseConstructor.call(this, $el, config);
+    };
+
+    /**
+     * Inherit from base module, for shared methods and interface
+     */
+    DoughBaseComponent.extend(Cookie);
+
+    Cookie.componentName = 'Cookie';
+
+    /**
+     * assuming that we don't have the cookie as the
+     * dough component has loaded if not there then we should be
+     */
+    Cookie.prototype.init = function() {
+        this.form = this.$el.find('.cookie-form');
+        this.addEvents();
+    };
+
+    Cookie.prototype.addEvents = function() {
+        var self = this;
+        this.form.submit(function(evt) {
+            evt.preventDefault();
+            self.addCookie();
+            self.removeDom();
+        });
+    };
+
+    Cookie.prototype.addCookie = function() {
+        var COOKIE_POLICY_MESSAGE_NAME = '_cookie_policy_acceptance';
+        var secondsInYear = 1000 * 60 * 60 * 24 * 365;
+        var years = 20;
+        document.cookie = COOKIE_POLICY_MESSAGE_NAME + '=y, expires=' + new Date(Date.now() + secondsInYear * years);
+    };
+
+    Cookie.prototype.removeDom = function() {
+        this.$el.remove();
+    };
+
+    return Cookie;
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -7,6 +7,7 @@
 //= depend_on_asset components/Header
 //= depend_on_asset components/Filters
 //= depend_on_asset components/Teaser
+//= depend_on_asset components/Cookie
 
 <%
   def requirejs_path(asset)
@@ -27,7 +28,8 @@
       Tooltip: requirejs_path('components/Tooltip'),
       Header: requirejs_path('components/Header'),
       Filters: requirejs_path('components/Filters'),
-      Teaser: requirejs_path('components/Teaser')
+      Teaser: requirejs_path('components/Teaser'),
+      Cookie: requirejs_path('components/Cookie')
     }
   }
 

--- a/app/assets/stylesheets/components/ui/_all.scss
+++ b/app/assets/stylesheets/components/ui/_all.scss
@@ -13,3 +13,4 @@
 @import 'search_results';
 @import 'tooltip';
 @import 'pagination';
+@import 'cookie';

--- a/app/assets/stylesheets/components/ui/_cookie.scss
+++ b/app/assets/stylesheets/components/ui/_cookie.scss
@@ -1,0 +1,40 @@
+.cookie-policy {
+  background: $color-blue-lighter;
+  padding: 0.5em 0;
+  position: fixed;
+  bottom: 0;
+  z-index: 1000;
+
+  @include respond-to($mq-m) {
+    position: static;
+  }
+}
+
+.cookie-form {
+  position: relative;
+}
+
+.cookie-policy-content {
+  padding: 0 $baseline-spacing 0 0;
+  margin: 0 5px 0 0;
+  font-size: 0.875em;
+}
+
+.cookie-submit {
+  position: absolute;
+  right: $baseline-spacing;
+  top: 0;
+  border: 0;
+  padding: 0;
+  background: $primary-blue-dark;
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+}
+
+.cookie-submit-icon {
+  margin: 3px;
+  width: 13px;
+  height: 13px;
+  color: $color-white;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include CookiePolicyAcceptance
   protect_from_forgery with: :exception
   rescue_from Mas::Cms::HttpRedirect, with: :redirect_page
 

--- a/app/controllers/concerns/cookie_policy_acceptance.rb
+++ b/app/controllers/concerns/cookie_policy_acceptance.rb
@@ -1,0 +1,15 @@
+module CookiePolicyAcceptance
+  extend ActiveSupport::Concern
+  include AbstractController::Helpers::ClassMethods
+
+  COOKIE_POLICY_MESSAGE_NAME = '_cookie_policy_acceptance'.freeze
+  COOKIE_POLICY_MESSAGE_VALUE = 'y'.freeze
+
+  included do
+    def cookie_policy_accepted?
+      cookies.permanent[COOKIE_POLICY_MESSAGE_NAME] ==
+        COOKIE_POLICY_MESSAGE_VALUE
+    end
+    helper_method :cookie_policy_accepted?
+  end
+end

--- a/app/controllers/cookie_policy_acceptances_controller.rb
+++ b/app/controllers/cookie_policy_acceptances_controller.rb
@@ -1,0 +1,11 @@
+class CookiePolicyAcceptancesController < ApplicationController
+  def create
+    cookies.permanent[COOKIE_POLICY_MESSAGE_NAME] = COOKIE_POLICY_MESSAGE_VALUE
+
+    respond_to do |format|
+      format.html do
+        redirect_back(fallback_location: root_path)
+      end
+    end
+  end
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,3 +1,29 @@
+<% unless cookie_policy_accepted? %>
+  <div class="cookie-policy" data-dough-component="Cookie">
+      <%= form_tag(
+        cookie_policy_acceptances_path,
+        remote: true,
+        authenticity_token: true,
+        class: 'cookie-form l-constrained' # hook class for js
+      ) do %>
+        <p class="cookie-policy-content">
+          <%= t('fincap.cookie_policy.message') %>
+          <%= link_to(
+          t('fincap.cookie_policy.link_description'),
+          t('fincap.cookie_policy.link_url')
+          ) %>
+        </p>
+
+        <button type="submit" class="cookie-submit">
+          <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--search cookie-submit-icon" focusable="false">
+            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--close"></use>
+          </svg>
+          <span class="visually-hidden">Close</span>
+        </button>
+      <% end %>
+  </div>
+<% end %>
+
 <header data-site-header data-dough-component="Header" data-dough-header-config='{"textClose":"Close Search"}' class="header">
   <div class="header-wrap">
     <div class="header-content">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,12 @@ en:
           - helping you to make the best use of our own %{link_insightAndResearch}.
         para_1: We tailor our support to the specific circumstances and needs of an organisation, with the overall aim of improving evidence and evaluation capacity across the financial capability community.
         para_2: If you would like to sign-up, please contact us at %{link}.
+    cookie_policy:
+      message: |
+        We use cookies to ensure that you get the best possible experience.
+        By continuing to use our website you are agreeing to their use.
+      link_description: Find out more about cookies.
+      link_url: /en/articles/cookies
     links_external:
       twitter: https://twitter.com/FinCapStrategy
       linkedin: https://www.linkedin.com/company/the-financial-capability-strategy-for-the-uk?trk=biz-companies-cym

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     resources :search_results, only: 'index', path: 'search'
   end
 
+  resources :cookie_policy_acceptances, only: :create
+
   # Styleguide
   get '/styleguide', to: 'styleguide#home'
   get 'styleguide/:page' => 'styleguide#show'

--- a/features/cookie_policy_acceptance.feature
+++ b/features/cookie_policy_acceptance.feature
@@ -1,0 +1,31 @@
+Feature: Cookie policy acceptance
+
+  Scenario: Visiting the website for the first time
+    Given I have not previously accepted the cookie policy
+    And I visit the homepage
+    Then I should see the cookie policy header
+      | Field            | Value                                                                                                                               |
+      | message_content  | We use cookies to ensure that you get the best possible experience. By continuing to use our website you are agreeing to their use. Find out more about cookies. |
+      | link_description | Find out more about cookies.                                                                                                        |
+      | link_url         | /en/articles/cookies                                                                                                                |
+
+  Scenario: Visiting the website and accepting the policy
+    Given I have not previously accepted the cookie policy
+    And I visit the homepage
+    When I accept the cookie policy
+    Then I should not see the cookie policy header
+
+  Scenario: Visiting the website subsequent times without accepting the policy
+    Given I have not previously accepted the cookie policy
+    And I visit the homepage
+    When I reload the page
+    Then I should see the cookie policy header
+      | Field            | Value                                                                                                                               |
+      | message_content  | We use cookies to ensure that you get the best possible experience. By continuing to use our website you are agreeing to their use. Find out more about cookies. |
+      | link_description | Find out more about cookies.                                                                                                        |
+      | link_url         | /en/articles/cookies                                                                                                                |
+
+  Scenario: Visiting the website after accepting the policy
+    Given I have previously accepted the cookie policy
+    And I visit the homepage
+    Then I should not see the cookie policy header

--- a/features/step_definitions/cookie_policy_acceptance_steps.rb
+++ b/features/step_definitions/cookie_policy_acceptance_steps.rb
@@ -1,0 +1,24 @@
+Given('I have not previously accepted the cookie policy') do
+  page.driver.browser.clear_cookies
+end
+
+Given('I have previously accepted the cookie policy') do
+  step 'I visit the homepage'
+  step 'I accept the cookie policy'
+end
+
+When('I accept the cookie policy') do
+  current_page.cookie_policy_header.close_button.click
+end
+
+Then('I should see the cookie policy header') do |table|
+  cookie_policy_header = current_page.cookie_policy_header
+
+  table.rows.each do |row|
+    expect(cookie_policy_header.send(row[0])).to eq(row[1])
+  end
+end
+
+Then('I should not see the cookie policy header') do
+  expect(current_page).not_to have_cookie_policy_header
+end

--- a/features/step_definitions/homepage_steps.rb
+++ b/features/step_definitions/homepage_steps.rb
@@ -2,6 +2,10 @@ Given('I entered into the Homepage') do
   home_page.load
 end
 
+When('I reload the page') do
+  visit(current_path)
+end
+
 When('I click the {string} cta') do |link_text|
   click_link(link_text)
 end

--- a/features/step_definitions/shared_page_steps.rb
+++ b/features/step_definitions/shared_page_steps.rb
@@ -1,3 +1,7 @@
+Given('I visit the homepage') do
+  home_page.load
+end
+
 Given('I visit the page {string}') do |path|
   visit(path)
 end

--- a/features/support/ui/page.rb
+++ b/features/support/ui/page.rb
@@ -41,7 +41,26 @@ module UI
     element :title, 'h2'
   end
 
+  class CookiePolicyHeader < SitePrism::Section
+    element :message, '.cookie-policy-content'
+    element :link, 'a'
+    element :close_button, 'button'
+
+    def message_content
+      message.text
+    end
+
+    def link_description
+      link.text
+    end
+
+    def link_url
+      link['href']
+    end
+  end
+
   class Page < SitePrism::Page
+    section :cookie_policy_header, CookiePolicyHeader, '.cookie-policy'
     sections :download_box,
              DownloadBoxSection, '.download-box ul.download-box__list li'
     sections :latest_news_item, LatestNewsItem, '.latest-news__list-item'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "sinon": "^4.4.2"
   },
   "scripts": {
-    "test": "./test.sh"
+    "test": "./test.sh",
+    "jstest": "./node_modules/karma/bin/karma start spec/javascripts/karma.conf.js"
   },
   "repository": {
     "type": "git",

--- a/spec/controllers/concerns/cookie_police_acceptance_spec.rb
+++ b/spec/controllers/concerns/cookie_police_acceptance_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe CookiePolicyAcceptance, type: :controller do
+  controller(ApplicationController) do
+    include CookiePolicyAcceptance
+  end
+
+  describe '.cookie_policy_accepted?' do
+    subject { controller.cookie_policy_accepted? }
+
+    context 'when the cookie policy has not been accepted' do
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the cookie policy has been accepted' do
+      before do
+        request.cookie_jar.permanent['_cookie_policy_acceptance'] = 'y'
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end

--- a/spec/javascripts/fixtures/Cookie.html
+++ b/spec/javascripts/fixtures/Cookie.html
@@ -1,0 +1,8 @@
+<div class="cookie-policy" data-dough-component="Cookie">
+    <form class="cookie-form l-constrained" action="/cookie_policy_acceptances" accept-charset="UTF-8"
+          data-remote="true" method="post"><input name="utf8" type="hidden" value="✓">
+        <input type="hidden" name="authenticity_token" value="fakeHidden">
+        <p class="cookie-policy-content">Some message <a href="/en/articles/cookies">Some link text</a></p>
+        <button type="submit" class="cookie-submit"><span class="visually-hidden">Close</span></button>
+    </form>
+</div>

--- a/spec/javascripts/test-main.js
+++ b/spec/javascripts/test-main.js
@@ -42,6 +42,8 @@ require.config({
     Tooltip: 'app/assets/javascripts/components/Tooltip',
     Header: 'app/assets/javascripts/components/Header',
     Filters: 'app/assets/javascripts/components/Filters',
-    Teaser: 'app/assets/javascripts/components/Teaser'
+    Teaser: 'app/assets/javascripts/components/Teaser',
+    Cookie: 'app/assets/javascripts/components/Cookie'
+
   }
 })

--- a/spec/javascripts/tests/Cookie_spec.js
+++ b/spec/javascripts/tests/Cookie_spec.js
@@ -1,0 +1,67 @@
+describe('Cookies', function() {
+    'use strict';
+
+    function init(self) {
+        self.obj.init();
+    }
+
+    beforeEach(function(done) {
+        var self = this;
+
+        fixture.setBase('spec/javascripts/fixtures');
+
+        requirejs(
+            ['jquery', 'Cookie'],
+            function($, Cookie) {
+                fixture.load('Cookie.html');
+
+                self.$component = $(fixture.el).find('[data-dough-component="Cookie"]');
+                self.obj = new Cookie(self.$component);
+                self.classPrototype = Cookie.prototype;
+
+                done();
+            }, done);
+    });
+
+    afterEach(function() {
+        fixture.cleanup();
+    });
+
+    describe('Init', function() {
+        it('should add a link property', function() {
+            init(this);
+            expect(this.obj.form).not.to.be.undefined;
+            expect(this.obj.form[0].nodeName.toLocaleLowerCase()).to.equal('form');
+        });
+
+        it('should call addEvents method', function() {
+            var addEventsSpy = sinon.spy(this.classPrototype, 'addEvents');
+            init(this);
+            expect(addEventsSpy.callCount).to.equal(1);
+            addEventsSpy.restore();
+        });
+    });
+
+    describe('Events', function() {
+        it('should call correct methods on form submit', function() {
+            var addCookieSpy = sinon.spy(this.classPrototype, 'addCookie');
+            var removeDomSpy = sinon.spy(this.classPrototype, 'removeDom');
+            init(this);
+            this.obj.form.submit();
+
+            expect(addCookieSpy.callCount).to.equal(1);
+            expect(removeDomSpy.callCount).to.equal(1);
+
+            addCookieSpy.restore();
+            removeDomSpy.restore();
+        });
+    });
+
+    describe('removeDom', function() {
+        it('should remove the dom element', function() {
+            expect(document.querySelector('.cookie-policy')).not.to.be.null;
+            this.obj.removeDom();
+            expect(document.querySelector('.cookie-policy')).to.be.null;
+        });
+    });
+});

--- a/spec/requests/cookie_policy_acceptances_spec.rb
+++ b/spec/requests/cookie_policy_acceptances_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'Cookie policy acceptance', type: :request do
+  describe 'POST /cookie_policy_acceptances' do
+    context 'when request format is html' do
+      context 'when there is a referer' do
+        before do
+          post '/cookie_policy_acceptances',
+               headers: { 'HTTP_REFERER' => '/previous_page' }
+        end
+
+        it 'redirects to the previous page' do
+          expect(response).to redirect_to('/previous_page')
+        end
+      end
+
+      context 'when there is no referer' do
+        before do
+          post '/cookie_policy_acceptances'
+        end
+
+        it 'redirects to the root page' do
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[TP 9613](https://moneyadviceservice.tpondemand.com/entity/9613-implement-cookie-messaging)

### Technical

This PR adds:

* A controller with an action to manage the creation of a permanent cookie
* A concern with a helper method to check the presence of the above cookie
* A conditional div displayed at the top of the header of every page

Front End 
Added a new javascript component (Cookie) to add the cookie using JS
Cookie is set to expire 20 years in the future as per the Rails version
Checked in Chrome, FF and Safari