### PR TITLE
[DEV APPROVED] TP: 9677, Comment: Adds missing end tag in SVG sprite

### DIFF
--- a/app/views/shared/svg/_icon_sprite.html.erb
+++ b/app/views/shared/svg/_icon_sprite.html.erb
@@ -375,7 +375,8 @@
     </g>
   </symbol>
   <symbol id="svg-icon--close" viewBox="0 0 136.1 136.3">
-  <path transform="rotate(45 68 68)" d="M56.1 136.3V79.8H0V56.2h56.1V0H80v56.1h56.1v23.6H80v56.5l-23.9.1z" fill="currentColor"/>
+    <path transform="rotate(45 68 68)" d="M56.1 136.3V79.8H0V56.2h56.1V0H80v56.1h56.1v23.6H80v56.5l-23.9.1z" fill="currentColor"/>
+  </symbol>
   <symbol id="svg-icon--plus" viewBox="0 0 136.1 136.3">
   <path d="M56.1 136.3V79.8H0V56.2h56.1V0H80v56.1h56.1v23.6H80v56.5l-23.9.1z" fill="currentColor"/>
   </symbol>


### PR DESCRIPTION
[TP9677](https://moneyadviceservice.tpondemand.com/RestUI/Board.aspx#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiQzgxRjcwQTZCMjdGNDBDNzY0NzgxOEUwRjBFMjQ3NkQifQ==&boardPopup=bug/9677/silent)

This addresses a problem in IE with rendering the close icons across the site. The cause is a missing end tag in the SVG Sprite, which has the effect that they appear as below: 

![image](https://user-images.githubusercontent.com/6080548/47425350-fd95b500-d781-11e8-9aef-43dc2b0c3aee.png)

This fix reverts them to the correct rendering: 

![image](https://user-images.githubusercontent.com/6080548/47425374-0d14fe00-d782-11e8-9e50-ffd844037b46.png)
