### PR TITLE
Fix failing feature test

### DIFF
--- a/features/evidence_hub_search.feature
+++ b/features/evidence_hub_search.feature
@@ -77,13 +77,13 @@ Feature: Evidence Hub Search
     When I search the evidence hub for summaries published in the last 2 years
     Then I should see "2" evidence summary
     And I should see the "first" evidence summary as
-      | Field               | Value                                                              |
-      | document title      | Moving forward together: peer support for people with problem debt |
-      | evidence type       | Insight                                                            |
-      | topics              | Credit Use and Debt                                                |
-      | countries           | England                                                            |
-      | year of publication | 2017                                                               |
-    And I should see the "first" evidence summary icon linking to "Insight" article
+      | Field               | Value                               |
+      | document title      | Looking after the pennies           |
+      | evidence type       | Evaluation                          |
+      | topics              | Topics: Budgeting and keeping track |
+      | countries           | Country/Countries: United Kingdom   |
+      | year of publication | 2019                                |
+    And I should see the "first" evidence summary icon linking to "evaluation" article
 
   Scenario: Search by single evidence type filter
     When I search the evidence hub for summaries of type "Evaluation"

--- a/spec/cassettes/fincap_cms/get/api/en/documents_jsonblocks_identifier_year_of_publication_blocks_value_2019_blocks_value_2018_document_type_Insight_document_type_Evaluation_document_type_Review_keyword_page_1_per_page_20.yml
+++ b/spec/cassettes/fincap_cms/get/api/en/documents_jsonblocks_identifier_year_of_publication_blocks_value_2019_blocks_value_2018_document_type_Insight_document_type_Evaluation_document_type_Review_keyword_page_1_per_page_20.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/en/documents.json?blocks%5B%5D%5Bidentifier%5D=year_of_publication&blocks%5B%5D%5Bvalue%5D%5B%5D=2019&blocks%5B%5D%5Bvalue%5D%5B%5D=2018&document_type%5B%5D=Insight&document_type%5B%5D=Evaluation&document_type%5B%5D=Review&keyword=&page=1&per_page=20
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Token token="mytoken"
+      User-Agent:
+      - Mas-Cms-Client/1.18.0 (Margo-Urey-00241.local; margourey; 87143) ruby/2.4.2
+        (198; x86_64-darwin16)
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Wed, 09 Jan 2019 17:18:44 GMT
+      status:
+      - 200 OK
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - '"56fb3a134fd6604eaefe027cc7fb784d"'
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 3ec386e9-1265-4e79-9a3c-5a53a0356f2a
+      x-runtime:
+      - '0.144971'
+    body:
+      encoding: UTF-8
+      string: '{"documents":[{"label":"Looking after the pennies","slug":"looking-after-the-pennies","full_path":"/en/evaluations/looking-after-the-pennies","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"evaluation","related_content":{"latest_blog_post_links":[{"title":"Are
+        reusable nappies worth it and how much do they cost?","path":"https://www.moneyadviceservice.org.uk/blog/are-reusable-nappies-worth-it-and-how-much-do-they-cost"},{"title":"Am
+        I entitled to a free eye test and NHS optical vouchers?","path":"https://www.moneyadviceservice.org.uk/blog/am-i-entitled-free-eye-test-nhs-optical-vouchers"},{"title":"Healthy
+        meal plans on a budget","path":"https://www.moneyadviceservice.org.uk/blog/healthy-meal-plans-on-a-budget"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":["how-can-we-improve-the-financial-capability-of-young-adults"],"blocks":[{"identifier":"content","content":"\u003cp\u003eThe
+        trackers are all available as free smartphone apps (although at the\ntime
+        of writing, Toshl is discontinued). Overall user numbers of the apps\nare
+        not given. However, 797 customers entered into the project (by\ncompleting
+        a first questionnaire and downloading an app) from across\nthe UK between
+        July and November 2016.\u003c/p\u003e\n\n\u003cp\u003eThe intervention was
+        undertaken in participants’ own time as part their\ndaily lives.\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"overview","content":"\u003cp\u003eAn
+        evaluation, commissioned by Royal London, of the impacts of using\n        simple
+        budgeting tools on customers’ money management attitudes and\n        behaviours.\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eWorking
+        age (18 - 65)\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOlder
+        people (65+)\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"topics","content":"\u003cp\u003eBudgeting
+        and keeping track\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"activities_and_setting","content":"\u003cp\u003eComparison
+        of budgeting apps vs. pen and paper methods\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"programme_delivery","content":"\u003cp\u003eMoney
+        Advice\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"countries","content":"\u003cp\u003eUnited
+        Kingdom\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2019\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"data_types","content":"\u003cp\u003eMeasured
+        Outcomes\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://www.royallondon.com/Documents/PDFs/2017/Royal%20London%20-%20Looking%20after%20the%20pennies.pdf\"\u003eLooking
+        after the pennies - full report\u003c/a\u003e\u003c/p\u003e\n\n\u003cpre\u003e\u003ccode\u003e  [Follow-up
+        report](https://fincap-two.cdn.prismic.io/fincap-two%2F0efeee0b-252a-4b13-b7f5-d05e66bdc6aa_final+report+-+royal+london+fincap.pptx)\n\u003c/code\u003e\u003c/pre\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"contact_information","content":"\u003cp\u003eMASPD
+        (in partnership with Company S.A)\n        T +44 (0)20 1234 5678 F +44 (0)20
+        4567 1234\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"measured_outcomes","content":"\u003cp\u003eFinancial
+        capability (Mindset)\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"measured_outcomes","content":"\u003cp\u003eFinancial
+        capability (Ability)\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"}],"translations":[]},{"label":"Moving
+        forward together: peer support for people with problem debt","slug":"moving-forward-together-peer-support-for-people-with-problem-debt","full_path":"/en/insights/moving-forward-together-peer-support-for-people-with-problem-debt","meta_description":"This
+        is an example description about a specific evidence summary.","meta_title":null,"category_names":[],"layout_identifier":"insight","related_content":{"latest_blog_post_links":[{"title":"Are
+        reusable nappies worth it and how much do they cost?","path":"https://www.moneyadviceservice.org.uk/blog/are-reusable-nappies-worth-it-and-how-much-do-they-cost"},{"title":"Am
+        I entitled to a free eye test and NHS optical vouchers?","path":"https://www.moneyadviceservice.org.uk/blog/am-i-entitled-free-eye-test-nhs-optical-vouchers"},{"title":"Healthy
+        meal plans on a budget","path":"https://www.moneyadviceservice.org.uk/blog/healthy-meal-plans-on-a-budget"}],"popular_links":[],"related_links":[],"previous_link":{},"next_link":{}},"published_at":null,"supports_amp":true,"tags":[],"blocks":[{"identifier":"content","content":"\u003cp\u003eContext\u003c/p\u003e\n\n\u003cp\u003eResearch
+        has found that there remains a real stigma around seeking advice\nfor debt,
+        with many people feeling that doing so means that they have\n ‘failed’, but
+        that talking about debt problems is also cathartic.\nThis suggests there is
+        potential value in peer-support for over-indebted\npeople, based on models
+        in other fields such as weight loss.\u003c/p\u003e\n\n\u003cp\u003ePeer support
+        is usually intended to encourage behaviour change and is\nprovided by peer
+        mentors (those who have led or given support within\npeer support programmes).\u003c/p\u003e\n\n\u003cp\u003eSuch
+        innovation, however, needs an evidence base, so research was needed\nto explore
+        the peer-support landscape and establish how it helps people\nto resolve their
+        difficulties and change their behaviour.\u003c/p\u003e\n","created_at":"2019-01-09T17:02:07.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"year_of_publication","content":"\u003cp\u003e2019\u003c/p\u003e\n","created_at":"2019-01-09T17:02:07.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"links_to_research","content":"\u003cp\u003e\u003ca
+        href=\"https://masassets.blob.core.windows.net/cms/files/000/000/631/original/MAS_MovingForwardTogether_Report.pdf\"\u003eMoving
+        forward together: peer support for people with problem debt - full report\u003c/a\u003e\u003c/p\u003e\n","created_at":"2019-01-09T17:02:07.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"contact_information","content":"\u003cp\u003epeersupport@moneyadviceservice.org.uk\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"overview","content":"\u003cp\u003eResearch
+        has found that there remains a real stigma around seeking\n        advice
+        for debt, with many people feeling that doing so means that\n        they
+        have ‘failed’, but that talking about debt problems is also\n        cathartic.\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"countries","content":"\u003cp\u003eEngland\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"topics","content":"\u003cp\u003eCredit
+        Use and Debt\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eOver-indebted
+        people\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"},{"identifier":"client_groups","content":"\u003cp\u003eWorking
+        age (18 - 65)\u003c/p\u003e\n","created_at":"2019-01-09T17:02:08.000Z","updated_at":"2019-01-09T17:02:08.000Z"}],"translations":[]}],"meta":{"results":2,"page":1,"per_page":20,"total_pages":1}}'
+    http_version: 
+  recorded_at: Wed, 09 Jan 2019 17:18:44 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
The test was failing as it checks for documents published in the
most recent 2 years. Originally the test was written in 2018 and
documents published in 2017 would be returned. Now that it is 2019,
2017 documents are no longer returned.

The fix was to update the seed data in the local cms to regenerate
the cassette.