### PR TITLE
[DEV APPROVED] 10156 Add the google tag manager script to the not_found page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
     bindex (0.5.0)
     bowndler (1.0.2)
       thor
-    brakeman (4.3.1)
+    brakeman (4.4.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (2.18.0)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,22 +27,7 @@
   <body>
     <%# START Google Tag Manager embed code %>
     <% if Rails.env.production? %>
-    <noscript>
-      <iframe src="//www.googletagmanager.com/ns.html?id=<%= Rails.application.config.google_tag_manager_id %>"
-              height="0" width="0" style="display:none;visibility:hidden"
-              title="Google Tag Manager"></iframe>
-    </noscript>
-    <script>
-        (function(w, d, s, l, i) {
-            w[l] = w[l] || [];
-            w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-            var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
-            j.async = true;
-            j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
-            f.parentNode.insertBefore(j, f.nextSibling);
-        })(window, document, 'script', 'dataLayer', '<%= Rails.application.config.google_tag_manager_id %>');
-    </script>
+        <%= render 'shared/google_tag_manager' %>
     <% end %>
     <%# END Google Tag Manager embed code %>
 

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -11,6 +11,9 @@
     <!--<![endif]-->
   </head>
   <body>
+    <% if Rails.env.production? %>
+      <%= render 'shared/google_tag_manager' %>
+    <% end %>
     <div class="l-constrained">
       <div class="l-1col">
         <a href="/">

--- a/app/views/shared/_google_tag_manager.erb
+++ b/app/views/shared/_google_tag_manager.erb
@@ -1,0 +1,16 @@
+<noscript>
+  <iframe src="//www.googletagmanager.com/ns.html?id=<%= Rails.application.config.google_tag_manager_id %>"
+          height="0" width="0" style="display:none;visibility:hidden"
+          title="Google Tag Manager"></iframe>
+</noscript>
+<script>
+    (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f.nextSibling);
+    })(window, document, 'script', 'dataLayer', '<%= Rails.application.config.google_tag_manager_id %>');
+</script>


### PR DESCRIPTION
[TP 10156](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=userstory/10156)

Display the google tag manager on the not found page.

