### PR TITLE
Add syslog logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,12 @@ gem 'okcomputer'
 gem 'pg', '~> 0.18'
 gem 'sass-rails', '~> 5.0'
 gem 'site_search', '0.2.0', source: 'http://gems.dev.mas.local'
-gem 'syslog-logger'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn-rails'
+
+group :production do
+  gem 'syslog-logger'
+end
 
 group :development, :test do
   gem 'brakeman', require: false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,7 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  config.logger = ActiveSupport::TaggedLogging.new(Logger::Syslog.new("fin-cap", Syslog::LOG_LOCAL6).tap {|log| log.level = Logger::INFO})
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
[TP](https://moneyadviceservice.tpondemand.com/entity/10311-fin-cap-application-logging)

Use syslog in production instead of the Rails default logger.