### PR TITLE
[DEV APPROVED] 10948 update socials

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -26,7 +26,7 @@
 
 .footer__social {
   @include respond-to($mq-m) {
-    @include column(4);
+    @include column(8);
   }
 }
 

--- a/app/views/shared/_twitter_feed.html.erb
+++ b/app/views/shared/_twitter_feed.html.erb
@@ -1,4 +1,4 @@
 <div class='sidepanel__twitter'>
-    <%= link_to('Tweets by FinCapStrategy', 'https://twitter.com/FinCapStrategy', {'class': 'twitter-timeline', 'data-height': '750', 'data-theme': 'light', 'data-aria-polite': 'assertive'}) %>
+    <%= link_to('Tweets by MoneyPensionsUK', 'https://twitter.com/MoneyPensionsUK', {'class': 'twitter-timeline', 'data-height': '750', 'data-theme': 'light', 'data-aria-polite': 'assertive'}) %>
     <script async src="//platform.twitter.com/widgets.js" chars  et="utf-8"></script>
 </div>

--- a/app/views/shared/footer/_footer_social.html.erb
+++ b/app/views/shared/footer/_footer_social.html.erb
@@ -7,24 +7,24 @@
       <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--twitter" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--twitter"></use>
       </svg>
-      <a href="https://twitter.com/fincapstrategy" class="footer__social-list-link external-link--white">
-        FinCap on Twitter
+      <a href="https://twitter.com/MoneyPensionsUK" class="footer__social-list-link external-link--white">
+        Money and Pensions Service on Twitter
       </a>
     </li>
     <li class="footer__social-list-item footer__social-list-item--linkedin">
       <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--linkedin" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--linkedin"></use>
       </svg>
-      <a href="https://www.linkedin.com/company/10915103/" class="footer__social-list-link">
-        FinCap on LinkedIn
+      <a href="https://www.linkedin.com/company/moneypensionsservice" class="footer__social-list-link">
+        Money and Pensions Service on LinkedIn
       </a>
     </li>
     <li class="footer__social-list-item footer__social-list-item--youtube">
       <svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--youtube" focusable="false">
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--youtube"></use>
       </svg>
-      <a href="https://www.youtube.com/channel/UCOXOEcLEUoHv8XVKhv6WW1Q/videos" class="footer__social-list-link">
-        FinCap on YouTube
+      <a href="https://www.youtube.com/channel/UCYJudym0jzgcnJjb4fXBMnA" class="footer__social-list-link">
+        Money and Pensions Service on YouTube
       </a>
     </li>
   <ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,7 +218,7 @@ en:
     links_external:
       twitter: https://twitter.com/FinCapStrategy
       linkedin: https://www.linkedin.com/company/the-financial-capability-strategy-for-the-uk?trk=biz-companies-cym
-      newsletter: https://moneyadviceservice.us8.list-manage.com/subscribe?u=876b00eec5e597f5575e5c4dc&id=2cfd1ff3d6
+      newsletter: https://singlefinancialguidancebody.us8.list-manage.com/subscribe?u=876b00eec5e597f5575e5c4dc&id=b6bd848f68
     footer:
       copyright: Copyright
       mps_provided_1: Fincap.org.uk

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -33,8 +33,8 @@ Feature: Homepage
       | I am interested in research and evaluation | /en/articles/our-approach         |
       | I need help to manage my money             | https://moneyadviceservice.org.uk |
     And I should see the stay in touch box
-      | title         | content                     | link                                                                                               |
-      | Stay in touch | Subscribe to our newsletter | https://moneyadviceservice.us8.list-manage.com/subscribe?u=876b00eec5e597f5575e5c4dc&id=2cfd1ff3d6 |
+      | title         | content                     | link                                                                                                        |
+      | Stay in touch | Subscribe to our newsletter | https://singlefinancialguidancebody.us8.list-manage.com/subscribe?u=876b00eec5e597f5575e5c4dc&id=b6bd848f68 |
 
     And The "description" meta tag should be present
     And The "title" meta tag should be present


### PR DESCRIPTION
[TP10948](https://maps.tpondemand.com/entity/10948-update-fincap-socials)

This PR updates social media links in three areas of the site: 

1) Footer: updates references to FinCap to Money and Pensions Service and updates the URLs. Additionally the width of the container has been increased to accommodate the additional text. 

![image](https://user-images.githubusercontent.com/6080548/68489892-e9fba600-023f-11ea-940a-0a40008ca484.png)

![image](https://user-images.githubusercontent.com/6080548/68489905-f253e100-023f-11ea-901c-85024e74c2bf.png)

2) The Twitter feed on articles pages. 

![image](https://user-images.githubusercontent.com/6080548/68490045-38a94000-0240-11ea-8775-d89c28e6d154.png)

![image](https://user-images.githubusercontent.com/6080548/68490064-4068e480-0240-11ea-9bc7-db937d757cbf.png)

3) The 'Subscribe' newsletter link. There is no visible change here, the URL has been updated. 

![image](https://user-images.githubusercontent.com/6080548/68490198-773efa80-0240-11ea-859e-8964ea4f45a4.png)



